### PR TITLE
fix: extend qBittorrent compatibility for Medusa and LazyLibrarian 🤖🤖🤖

### DIFF
--- a/src/.eslintrc.cjs
+++ b/src/.eslintrc.cjs
@@ -1,0 +1,25 @@
+const baseConfig = require("../.eslintrc.cjs")
+
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+  ...baseConfig,
+  root: true,
+  overrides: [
+    ...baseConfig.overrides.map((override) => {
+      if (override.parser !== "@typescript-eslint/parser") {
+        return override
+      }
+
+      return {
+        ...override,
+        parser: require.resolve("@typescript-eslint/parser"),
+      }
+    }),
+    {
+      files: ["server.js"],
+      env: {
+        node: true,
+      },
+    },
+  ],
+}

--- a/src/amule/amule.tsx
+++ b/src/amule/amule.tsx
@@ -182,6 +182,14 @@ export async function amuleDoResume(hash: string) {
   return await fetchAmuleApi(url)
 }
 
+export async function amuleDoPause(hash: string) {
+  const url = new URL(`${host}/api.php`)
+  url.searchParams.set("do", "pause")
+  url.searchParams.set("hash", hash)
+
+  return await fetchAmuleApi(url)
+}
+
 export async function amuleDoReloadShared() {
   const url = new URL(`${host}/api.php`)
   url.searchParams.set("do", "reload-shared")
@@ -314,6 +322,8 @@ export const amuleGetDownloads = staleWhileRevalidate(async function () {
           }
         })(),
       }
+      // category is omitted from the download payload returned to callers
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { category, ...good } = o
       return good
     })

--- a/src/amule/api.php
+++ b/src/amule/api.php
@@ -148,17 +148,17 @@
             echo '{}';
             break;
         case "cancel":
-            $hash = $_GET["hash"];
+            $hash = get_valid_download_hash();
             amule_do_download_cmd($hash, 'cancel');
             echo '{}';
             break;
         case "resume":
-            $hash = $_GET["hash"];
+            $hash = get_valid_download_hash();
             amule_do_download_cmd($hash, 'resume');
             echo '{}';
             break;
         case "pause":
-            $hash = $_GET["hash"];
+            $hash = get_valid_download_hash();
             amule_do_download_cmd($hash, 'pause');
             echo '{}';
             break;
@@ -169,6 +169,18 @@
         case "reconnect":
             echo '{ TODO: 1 }';
             break;
+    }
+
+    function get_valid_download_hash() {
+        $hash = isset($_GET["hash"]) ? $_GET["hash"] : "";
+
+        if (!preg_match('/\A[0-9a-fA-F]{32}\z/', $hash)) {
+            http_response_code(400);
+            echo '{"error":"invalid hash"}';
+            exit;
+        }
+
+        return strtoupper($hash);
     }
 
     function str_value($value) {

--- a/src/amule/api.php
+++ b/src/amule/api.php
@@ -172,7 +172,13 @@
     }
 
     function get_valid_download_hash() {
-        $hash = isset($_GET["hash"]) ? $_GET["hash"] : "";
+        if (!isset($_GET["hash"]) || !is_string($_GET["hash"])) {
+            http_response_code(400);
+            echo '{"error":"invalid hash"}';
+            exit;
+        }
+
+        $hash = $_GET["hash"];
 
         if (!preg_match('/\A[0-9a-fA-F]{32}\z/', $hash)) {
             http_response_code(400);

--- a/src/amule/api.php
+++ b/src/amule/api.php
@@ -1,5 +1,5 @@
 <?php
-    switch ($HTTP_GET_VARS["get"]) {
+    switch ($_GET["get"]) {
         case "categories":
             $categories = amule_get_categories();
             echo "{";
@@ -131,34 +131,34 @@
             break;
     }
 
-    switch ($HTTP_GET_VARS["do"]) {
+    switch ($_GET["do"]) {
         case "search":
-            $q = $HTTP_GET_VARS["q"];
-            $ext = $HTTP_GET_VARS["ext"];
-            $searchType = $HTTP_GET_VARS["searchType"];
-            $minSize = $HTTP_GET_VARS["minSize"];
+            $q = $_GET["q"];
+            $ext = $_GET["ext"];
+            $searchType = $_GET["searchType"];
+            $minSize = $_GET["minSize"];
             amule_do_search_start_cmd($q, $ext, "", $searchType, "", $minSize, 0);
             echo '{}';
             break;
         case "download":
             $cat = amule_get_categories();
-            $link = $HTTP_GET_VARS["link"];
-            $category = $HTTP_GET_VARS["category"];
+            $link = $_GET["link"];
+            $category = $_GET["category"];
             amule_do_ed2k_download_cmd($link, $category);
             echo '{}';
             break;
         case "cancel":
-            $hash = $HTTP_GET_VARS["hash"];
+            $hash = $_GET["hash"];
             amule_do_download_cmd($hash, 'cancel');
             echo '{}';
             break;
         case "resume":
-            $hash = $HTTP_GET_VARS["hash"];
+            $hash = $_GET["hash"];
             amule_do_download_cmd($hash, 'resume');
             echo '{}';
             break;
         case "pause":
-            $hash = $HTTP_GET_VARS["hash"];
+            $hash = $_GET["hash"];
             amule_do_download_cmd($hash, 'pause');
             echo '{}';
             break;

--- a/src/amule/api.php
+++ b/src/amule/api.php
@@ -157,6 +157,11 @@
             amule_do_download_cmd($hash, 'resume');
             echo '{}';
             break;
+        case "pause":
+            $hash = $HTTP_GET_VARS["hash"];
+            amule_do_download_cmd($hash, 'pause');
+            echo '{}';
+            break;
         case "reload-shared":
             amule_do_reload_shared_cmd();
             echo '{}';

--- a/src/app/data/downloadClient.ts
+++ b/src/app/data/downloadClient.ts
@@ -18,7 +18,10 @@ import {
   type ParsedQbittorrentHashSelection,
   selectionFromParsedHashes,
 } from "~/utils/qbittorrentHash"
-import { resolveDeletionFilePath } from "~/utils/qbittorrentDeletion"
+import {
+  resolveDeletionFilePath,
+  unlinkExistingFile,
+} from "~/utils/qbittorrentDeletion"
 
 export type HashMetadata = {
   category: string
@@ -356,7 +359,7 @@ async function deleteSelectedKnownFile(
     return
   }
 
-  await unlink(targetPath)
+  await unlinkExistingFile(targetPath, unlink)
 }
 
 export async function remove(hashes: string[], deleteFiles = true) {

--- a/src/app/data/downloadClient.ts
+++ b/src/app/data/downloadClient.ts
@@ -41,10 +41,17 @@ function setPausedByApi(hash: string, paused: boolean) {
   metadataDb.data[hash] = next
 }
 
-async function filterKnownDownloadHashes(
-  hashes: string[]
+export type TorrentHashSelection = "all" | string[]
+
+export async function resolveKnownDownloadHashes(
+  selection: TorrentHashSelection
 ): Promise<string[]> {
   const downloads = await amuleGetDownloads()
+
+  if (selection === "all") {
+    return [...new Set(downloads.map((download) => download.hash))]
+  }
+
   const knownHashes = new Map(
     downloads.map((download) => [
       download.hash.toUpperCase(),
@@ -52,15 +59,13 @@ async function filterKnownDownloadHashes(
     ])
   )
 
-  return [
-    ...new Set(hashes.map((hash) => hash.toUpperCase())),
-  ]
+  return [...new Set(selection.map((hash) => hash.toUpperCase()))]
     .map((hash) => knownHashes.get(hash))
     .filter((hash): hash is string => Boolean(hash))
 }
 
-export async function pauseTorrents(hashes: string[]) {
-  const knownHashes = await filterKnownDownloadHashes(hashes)
+export async function pauseTorrents(selection: TorrentHashSelection) {
+  const knownHashes = await resolveKnownDownloadHashes(selection)
 
   await Promise.all(
     knownHashes.map(async (hash) => {
@@ -70,8 +75,8 @@ export async function pauseTorrents(hashes: string[]) {
   )
 }
 
-export async function resumeTorrents(hashes: string[]) {
-  const knownHashes = await filterKnownDownloadHashes(hashes)
+export async function resumeTorrents(selection: TorrentHashSelection) {
+  const knownHashes = await resolveKnownDownloadHashes(selection)
 
   await Promise.all(
     knownHashes.map(async (hash) => {

--- a/src/app/data/downloadClient.ts
+++ b/src/app/data/downloadClient.ts
@@ -41,9 +41,29 @@ function setPausedByApi(hash: string, paused: boolean) {
   metadataDb.data[hash] = next
 }
 
+async function filterKnownDownloadHashes(
+  hashes: string[]
+): Promise<string[]> {
+  const downloads = await amuleGetDownloads()
+  const knownHashes = new Map(
+    downloads.map((download) => [
+      download.hash.toUpperCase(),
+      download.hash,
+    ])
+  )
+
+  return [
+    ...new Set(hashes.map((hash) => hash.toUpperCase())),
+  ]
+    .map((hash) => knownHashes.get(hash))
+    .filter((hash): hash is string => Boolean(hash))
+}
+
 export async function pauseTorrents(hashes: string[]) {
+  const knownHashes = await filterKnownDownloadHashes(hashes)
+
   await Promise.all(
-    hashes.map(async (hash) => {
+    knownHashes.map(async (hash) => {
       await amuleDoPause(hash)
       setPausedByApi(hash, true)
     })
@@ -51,8 +71,10 @@ export async function pauseTorrents(hashes: string[]) {
 }
 
 export async function resumeTorrents(hashes: string[]) {
+  const knownHashes = await filterKnownDownloadHashes(hashes)
+
   await Promise.all(
-    hashes.map(async (hash) => {
+    knownHashes.map(async (hash) => {
       await amuleDoResume(hash)
       setPausedByApi(hash, false)
     })

--- a/src/app/data/downloadClient.ts
+++ b/src/app/data/downloadClient.ts
@@ -16,13 +16,9 @@ import { staleWhileRevalidate } from "~/utils/memoize"
 import {
   externalToInternalEd2kHash,
   type ParsedQbittorrentHashSelection,
+  selectionFromParsedHashes,
 } from "~/utils/qbittorrentHash"
-import {
-  COMPLETE_DOWNLOAD_ROOT,
-  INCOMPLETE_DOWNLOAD_ROOT,
-  resolveSafeFilePath,
-  SHARED_DOWNLOAD_ROOT,
-} from "~/utils/qbittorrentPathSafety"
+import { resolveDeletionFilePath } from "~/utils/qbittorrentDeletion"
 
 export type HashMetadata = {
   category: string
@@ -87,11 +83,25 @@ function clearRemovedFromApi(hash: string) {
   metadataDb.data[hash] = next
 }
 
+function persistAddedOn(hash: string) {
+  if (metadataDb.data[hash]?.addedOn !== undefined) {
+    return
+  }
+
+  const existing = metadataDb.data[hash]
+  metadataDb.data[hash] = {
+    category: existing?.category ?? "",
+    ...existing,
+    addedOn: Date.now(),
+  }
+}
+
 function persistCompletionOn(hash: string, completed: boolean) {
   if (!completed || metadataDb.data[hash]?.completionOn !== undefined) {
     return
   }
 
+  persistAddedOn(hash)
   const existing = metadataDb.data[hash]
   metadataDb.data[hash] = {
     category: existing?.category ?? "",
@@ -138,19 +148,7 @@ export async function resolveApiVisibleHashes(
     .filter((hash): hash is string => Boolean(hash))
 }
 
-export function selectionFromParsedHashes(
-  parsed: ParsedQbittorrentHashSelection
-): TorrentHashSelection | null {
-  if (parsed.kind === "none") {
-    return null
-  }
-
-  if (parsed.kind === "all") {
-    return "all"
-  }
-
-  return parsed.hashes
-}
+export { selectionFromParsedHashes }
 
 export async function pauseTorrents(selection: TorrentHashSelection) {
   const knownHashes = await resolveKnownDownloadHashes(selection)
@@ -182,8 +180,9 @@ export function invalidateAmuleClientFilesCache() {
 }
 
 const getAmuleClientFilesCached = staleWhileRevalidate(async function (
-  _generation: number
+  generation: number
 ) {
+  void generation
   const uploads = await amuleGetUploads()
   const downloads = [...(await amuleGetDownloads())]
   const shared = (await amuleGetShared())
@@ -245,6 +244,7 @@ export async function getDownloadClientFiles() {
         !permanentlyRemovedHashes.has(file.hash)
     )
     .map((file) => {
+      persistAddedOn(file.hash)
       persistCompletionOn(file.hash, file.progress >= 1)
       return {
         ...file,
@@ -319,6 +319,8 @@ export async function removeTorrents(
 
       if (!deleteFiles) {
         if (active) {
+          // aMule may leave partial data in /downloads/incomplete; only the API
+          // entry is removed here.
           await amuleDoDelete(hash)
         }
         markRemovedFromApi(hash)
@@ -328,7 +330,7 @@ export async function removeTorrents(
       await amuleDoDelete(hash)
 
       if (file.name) {
-        await deleteKnownFile(file.name)
+        await deleteSelectedKnownFile(file.name, isCompleted)
       }
 
       delete metadataDb.data[hash]
@@ -343,20 +345,18 @@ export async function removeTorrents(
   invalidateAmuleClientFilesCache()
 }
 
-async function deleteKnownFile(fileName: string) {
-  for (const root of [
-    COMPLETE_DOWNLOAD_ROOT,
-    SHARED_DOWNLOAD_ROOT,
-    INCOMPLETE_DOWNLOAD_ROOT,
-  ]) {
-    const safePath = resolveSafeFilePath(root, fileName)
-    if (safePath && existsSync(safePath)) {
-      await unlink(safePath).catch(() => void 0)
-    }
+async function deleteSelectedKnownFile(
+  fileName: string,
+  isCompleted: boolean
+): Promise<void> {
+  const targetPath = resolveDeletionFilePath(fileName, isCompleted, existsSync)
+  if (!targetPath) {
+    return
   }
+
+  await unlink(targetPath)
 }
 
-// Backward-compatible alias used by existing routes during transition.
 export async function remove(hashes: string[], deleteFiles = true) {
   await removeTorrents(hashes, deleteFiles)
 }
@@ -364,3 +364,5 @@ export async function remove(hashes: string[], deleteFiles = true) {
 export function setCategory(hash: string, category: string) {
   metadataDb.data[hash] = spreadMetadata(hash, { category })
 }
+
+export type { ParsedQbittorrentHashSelection }

--- a/src/app/data/downloadClient.ts
+++ b/src/app/data/downloadClient.ts
@@ -4,7 +4,9 @@ import {
   amuleGetShared,
   amuleDoDownload,
   amuleDoDelete,
+  amuleDoPause,
   amuleDoReloadShared,
+  amuleDoResume,
 } from "amule/amule"
 import { toEd2kLink } from "~/links"
 import { unlink } from "node:fs/promises"
@@ -12,8 +14,50 @@ import { createJsonDb } from "~/utils/jsonDb"
 import { staleWhileRevalidate } from "~/utils/memoize"
 
 export const metadataDb = createJsonDb<
-  Record<string, { category: string; addedOn: number }>
+  Record<
+    string,
+    { category: string; addedOn: number; pausedByApi?: boolean }
+  >
 >("/config/hash-metadata.json", {})
+
+function setPausedByApi(hash: string, paused: boolean) {
+  const existing = metadataDb.data[hash]
+
+  if (paused) {
+    metadataDb.data[hash] = {
+      category: existing?.category ?? "",
+      addedOn: existing?.addedOn ?? Date.now(),
+      pausedByApi: true,
+    }
+    return
+  }
+
+  if (!existing) {
+    return
+  }
+
+  const next = { ...existing }
+  delete next.pausedByApi
+  metadataDb.data[hash] = next
+}
+
+export async function pauseTorrents(hashes: string[]) {
+  await Promise.all(
+    hashes.map(async (hash) => {
+      await amuleDoPause(hash)
+      setPausedByApi(hash, true)
+    })
+  )
+}
+
+export async function resumeTorrents(hashes: string[]) {
+  await Promise.all(
+    hashes.map(async (hash) => {
+      await amuleDoResume(hash)
+      setPausedByApi(hash, false)
+    })
+  )
+}
 
 export const getDownloadClientFiles = staleWhileRevalidate(async function () {
   const uploads = await amuleGetUploads()
@@ -76,8 +120,10 @@ export async function download(
 }
 
 export function setCategory(hash: string, category: string) {
+  const existing = metadataDb.data[hash]
   metadataDb.data[hash] = {
-    addedOn: Date.now(),
+    ...existing,
+    addedOn: existing?.addedOn ?? Date.now(),
     category: category,
   }
 }

--- a/src/app/data/downloadClient.ts
+++ b/src/app/data/downloadClient.ts
@@ -10,28 +10,59 @@ import {
 } from "amule/amule"
 import { toEd2kLink } from "~/links"
 import { unlink } from "node:fs/promises"
+import { existsSync } from "node:fs"
 import { createJsonDb } from "~/utils/jsonDb"
 import { staleWhileRevalidate } from "~/utils/memoize"
+import {
+  externalToInternalEd2kHash,
+  type ParsedQbittorrentHashSelection,
+} from "~/utils/qbittorrentHash"
+import {
+  COMPLETE_DOWNLOAD_ROOT,
+  INCOMPLETE_DOWNLOAD_ROOT,
+  resolveSafeFilePath,
+  SHARED_DOWNLOAD_ROOT,
+} from "~/utils/qbittorrentPathSafety"
 
-export const metadataDb = createJsonDb<
-  Record<
-    string,
-    { category: string; addedOn: number; pausedByApi?: boolean }
-  >
->("/config/hash-metadata.json", {})
+export type HashMetadata = {
+  category: string
+  addedOn: number
+  pausedByApi?: boolean
+  removedFromApi?: boolean
+  completionOn?: number
+}
+
+export const metadataDb = createJsonDb<Record<string, HashMetadata>>(
+  "/config/hash-metadata.json",
+  {}
+)
+
+export type TorrentHashSelection = "all" | string[]
+
+export type DownloadClientFile = Awaited<
+  ReturnType<typeof getDownloadClientFiles>
+>[number]
+
+function spreadMetadata(
+  hash: string,
+  patch: Partial<HashMetadata>
+): HashMetadata {
+  const existing = metadataDb.data[hash]
+  return {
+    category: existing?.category ?? "",
+    addedOn: existing?.addedOn ?? Date.now(),
+    ...existing,
+    ...patch,
+  }
+}
 
 function setPausedByApi(hash: string, paused: boolean) {
-  const existing = metadataDb.data[hash]
-
   if (paused) {
-    metadataDb.data[hash] = {
-      category: existing?.category ?? "",
-      addedOn: existing?.addedOn ?? Date.now(),
-      pausedByApi: true,
-    }
+    metadataDb.data[hash] = spreadMetadata(hash, { pausedByApi: true })
     return
   }
 
+  const existing = metadataDb.data[hash]
   if (!existing) {
     return
   }
@@ -41,7 +72,34 @@ function setPausedByApi(hash: string, paused: boolean) {
   metadataDb.data[hash] = next
 }
 
-export type TorrentHashSelection = "all" | string[]
+function markRemovedFromApi(hash: string) {
+  metadataDb.data[hash] = spreadMetadata(hash, { removedFromApi: true })
+}
+
+function clearRemovedFromApi(hash: string) {
+  const existing = metadataDb.data[hash]
+  if (!existing?.removedFromApi) {
+    return
+  }
+
+  const next = { ...existing }
+  delete next.removedFromApi
+  metadataDb.data[hash] = next
+}
+
+function persistCompletionOn(hash: string, completed: boolean) {
+  if (!completed || metadataDb.data[hash]?.completionOn !== undefined) {
+    return
+  }
+
+  const existing = metadataDb.data[hash]
+  metadataDb.data[hash] = {
+    category: existing?.category ?? "",
+    addedOn: existing?.addedOn ?? Date.now(),
+    ...existing,
+    completionOn: Date.now(),
+  }
+}
 
 export async function resolveKnownDownloadHashes(
   selection: TorrentHashSelection
@@ -53,15 +111,45 @@ export async function resolveKnownDownloadHashes(
   }
 
   const knownHashes = new Map(
-    downloads.map((download) => [
-      download.hash.toUpperCase(),
-      download.hash,
-    ])
+    downloads.map((download) => [download.hash.toUpperCase(), download.hash])
   )
 
   return [...new Set(selection.map((hash) => hash.toUpperCase()))]
     .map((hash) => knownHashes.get(hash))
     .filter((hash): hash is string => Boolean(hash))
+}
+
+export async function resolveApiVisibleHashes(
+  selection: TorrentHashSelection
+): Promise<string[]> {
+  const files = await getDownloadClientFiles()
+  const visibleHashes = files.map((file) => file.hash)
+
+  if (selection === "all") {
+    return visibleHashes
+  }
+
+  const visible = new Map(
+    visibleHashes.map((hash) => [hash.toUpperCase(), hash])
+  )
+
+  return [...new Set(selection.map((hash) => hash.toUpperCase()))]
+    .map((hash) => visible.get(hash))
+    .filter((hash): hash is string => Boolean(hash))
+}
+
+export function selectionFromParsedHashes(
+  parsed: ParsedQbittorrentHashSelection
+): TorrentHashSelection | null {
+  if (parsed.kind === "none") {
+    return null
+  }
+
+  if (parsed.kind === "all") {
+    return "all"
+  }
+
+  return parsed.hashes
 }
 
 export async function pauseTorrents(selection: TorrentHashSelection) {
@@ -86,13 +174,20 @@ export async function resumeTorrents(selection: TorrentHashSelection) {
   )
 }
 
-export const getDownloadClientFiles = staleWhileRevalidate(async function () {
+let amuleClientFilesGeneration = 0
+const permanentlyRemovedHashes = new Set<string>()
+
+export function invalidateAmuleClientFilesCache() {
+  amuleClientFilesGeneration += 1
+}
+
+const getAmuleClientFilesCached = staleWhileRevalidate(async function (
+  _generation: number
+) {
   const uploads = await amuleGetUploads()
-  const downloads = [...await amuleGetDownloads()]
+  const downloads = [...(await amuleGetDownloads())]
   const shared = (await amuleGetShared())
-    .filter(
-      (f) => !downloads.some((d) => d.hash === f.hash)
-    )
+    .filter((f) => !downloads.some((d) => d.hash === f.hash))
     .map(
       (f) =>
         ({
@@ -113,9 +208,7 @@ export const getDownloadClientFiles = staleWhileRevalidate(async function () {
         }) as const
     )
 
-  const metadata = metadataDb.data
-
-  const files = [
+  return [
     ...downloads.sort(
       (a, b) =>
         (b.speed > 0 ? 1 : 0) - (a.speed > 0 ? 1 : 0) ||
@@ -123,60 +216,151 @@ export const getDownloadClientFiles = staleWhileRevalidate(async function () {
         b.speed - a.speed
     ),
     ...shared,
-  ].map((f) => ({
-    ...f,
+  ].map((file) => ({
+    ...file,
     up_speed: uploads
-      .filter((u) => u.name === f.name)
+      .filter((u) => u.name === file.name)
       .map((u) => u.xfer_speed)
       .reduce((prev, curr) => prev + curr, 0),
-    meta: metadata[f.hash],
   }))
+})
+
+async function getAmuleClientFiles() {
+  return getAmuleClientFilesCached(amuleClientFilesGeneration)
+}
+
+export async function getDownloadClientFiles() {
+  const files = await getAmuleClientFiles()
+
+  for (const hash of [...permanentlyRemovedHashes]) {
+    if (!files.some((file) => file.hash === hash)) {
+      permanentlyRemovedHashes.delete(hash)
+    }
+  }
 
   return files
-})
+    .filter(
+      (file) =>
+        !metadataDb.data[file.hash]?.removedFromApi &&
+        !permanentlyRemovedHashes.has(file.hash)
+    )
+    .map((file) => {
+      persistCompletionOn(file.hash, file.progress >= 1)
+      return {
+        ...file,
+        meta: metadataDb.data[file.hash],
+      }
+    })
+}
+
+export async function getApiVisibleFileByHash(
+  hashInput: string
+): Promise<DownloadClientFile | undefined> {
+  const internalHash = externalToInternalEd2kHash(hashInput)
+  if (!internalHash) {
+    return undefined
+  }
+
+  const files = await getDownloadClientFiles()
+  return files.find((file) => file.hash.toUpperCase() === internalHash)
+}
 
 export async function download(
   hash: string,
   name: string,
   size: number,
-  category: string
+  category: string,
+  options?: { paused?: boolean }
 ) {
   const ed2kLink = toEd2kLink(hash, name, size)
   await amuleDoDownload(ed2kLink)
-  setCategory(hash, category)
+
+  metadataDb.data[hash] = spreadMetadata(hash, { category })
+  clearRemovedFromApi(hash)
+  permanentlyRemovedHashes.delete(hash)
+
+  if (options?.paused) {
+    await amuleDoPause(hash)
+    setPausedByApi(hash, true)
+  }
+
+  invalidateAmuleClientFilesCache()
+}
+
+export function setCategoryForKnownHashes(hashes: string[], category: string) {
+  for (const hash of hashes) {
+    metadataDb.data[hash] = spreadMetadata(hash, { category })
+  }
+}
+
+export async function removeTorrents(
+  selection: TorrentHashSelection,
+  deleteFiles: boolean
+) {
+  const hashes = await resolveApiVisibleHashes(selection)
+  if (!hashes.length) {
+    return
+  }
+
+  const downloads = await amuleGetDownloads()
+  const shared = await amuleGetShared()
+
+  await Promise.all(
+    hashes.map(async (hash) => {
+      const active = downloads.find((entry) => entry.hash === hash)
+      const completed = shared.find((entry) => entry.hash === hash)
+      const file = active ?? completed
+
+      if (!file) {
+        return
+      }
+
+      const isCompleted = !active && Boolean(completed)
+
+      if (!deleteFiles) {
+        if (active) {
+          await amuleDoDelete(hash)
+        }
+        markRemovedFromApi(hash)
+        return
+      }
+
+      await amuleDoDelete(hash)
+
+      if (file.name) {
+        await deleteKnownFile(file.name)
+      }
+
+      delete metadataDb.data[hash]
+      permanentlyRemovedHashes.add(hash)
+    })
+  )
+
+  if (deleteFiles) {
+    await amuleDoReloadShared()
+  }
+
+  invalidateAmuleClientFilesCache()
+}
+
+async function deleteKnownFile(fileName: string) {
+  for (const root of [
+    COMPLETE_DOWNLOAD_ROOT,
+    SHARED_DOWNLOAD_ROOT,
+    INCOMPLETE_DOWNLOAD_ROOT,
+  ]) {
+    const safePath = resolveSafeFilePath(root, fileName)
+    if (safePath && existsSync(safePath)) {
+      await unlink(safePath).catch(() => void 0)
+    }
+  }
+}
+
+// Backward-compatible alias used by existing routes during transition.
+export async function remove(hashes: string[], deleteFiles = true) {
+  await removeTorrents(hashes, deleteFiles)
 }
 
 export function setCategory(hash: string, category: string) {
-  const existing = metadataDb.data[hash]
-  metadataDb.data[hash] = {
-    ...existing,
-    addedOn: existing?.addedOn ?? Date.now(),
-    category: category,
-  }
-}
-
-export async function remove(hashes: string[]) {
-  if (hashes.length) {
-    const downloads = await amuleGetDownloads()
-    const shared = await amuleGetShared()
-
-    await Promise.all(
-      hashes.map(async (hash) => {
-        const file =
-          downloads.find((v) => v.hash === hash) ??
-          shared.find((v) => v.hash === hash)
-
-        await amuleDoDelete(hash)
-
-        if (file) {
-          await unlink(`/downloads/complete/${file.name}`).catch(() => void 0)
-          await unlink(`/tmp/shared/${file.name}`).catch(() => void 0)
-        }
-
-        delete metadataDb.data[hash]
-      })
-    )
-
-    await amuleDoReloadShared()
-  }
+  metadataDb.data[hash] = spreadMetadata(hash, { category })
 }

--- a/src/app/data/downloadClient.ts
+++ b/src/app/data/downloadClient.ts
@@ -323,6 +323,8 @@ export async function removeTorrents(
           // entry is removed here.
           await amuleDoDelete(hash)
         }
+        // Completed files stay on disk and remain in aMule's shared list; only
+        // the qBittorrent-compatible API entry is hidden.
         markRemovedFromApi(hash)
         return
       }

--- a/src/app/links.tsx
+++ b/src/app/links.tsx
@@ -31,7 +31,7 @@ export function toEd2kLink(hash: string, name: string, size: number) {
 
 export function fromEd2kLink(ed2kLink: string) {
   const extractEd2kLinkInfo =
-    /ed2k:\/\/\|file\|(?<name>[^\|]+)\|(?<size>[^\|]+)\|(?<hash>[^\|]+)\|/
+    /ed2k:\/\/\|file\|(?<name>[^|]+)\|(?<size>[^|]+)\|(?<hash>[^|]+)\|/
 
   const { hash, name, size } = extractEd2kLinkInfo.exec(ed2kLink)?.groups ?? {}
 

--- a/src/app/links.tsx
+++ b/src/app/links.tsx
@@ -1,4 +1,8 @@
 import base32 from "hi-base32"
+import {
+  MagnetParseError,
+  parseSyntheticMagnetLink,
+} from "~/utils/qbittorrentMagnet"
 
 export function toMagnetLink(hash: string, name: string, size: number) {
   const hashBuffer = Buffer.from(hash, "hex")
@@ -10,23 +14,15 @@ export function toMagnetLink(hash: string, name: string, size: number) {
 }
 
 export function fromMagnetLink(magnetLink: string) {
-  const extractMagnetLinkInfo =
-    /magnet:\?xt=urn:btih:(?<hash>.*)&dn=(?<name>.*)&xl=(?<size>[^&]+)&tr=http:\/\/emulerr/
-  const {
-    hash: base32Hash,
-    name,
-    size,
-  } = extractMagnetLinkInfo.exec(magnetLink)?.groups ?? {}
+  try {
+    return parseSyntheticMagnetLink(magnetLink)
+  } catch (error) {
+    if (error instanceof MagnetParseError) {
+      throw new Error(error.message)
+    }
 
-  if (!base32Hash || !name || !size) {
-    throw new Error("Invalid magnet link")
+    throw error
   }
-
-  const hash = Buffer.from(base32.decode.asBytes(base32Hash))
-    .toString("hex")
-    .substring(0, 32)
-    .toUpperCase()
-  return { hash, name: decodeURIComponent(name), size: parseInt(size) }
 }
 
 export function toEd2kLink(hash: string, name: string, size: number) {

--- a/src/app/root.tsx
+++ b/src/app/root.tsx
@@ -5,7 +5,6 @@ import {
   Scripts,
   ScrollRestoration,
   useNavigate,
-  useRouteError,
 } from "@remix-run/react"
 
 import stylesheet from "~/global.css?url"
@@ -51,5 +50,5 @@ export function ErrorBoundary() {
 
   useEffect(() => {
     navigate(".", { replace: true })
-  }, [])
+  }, [navigate])
 }

--- a/src/app/routes/_shell.search.tsx
+++ b/src/app/routes/_shell.search.tsx
@@ -50,6 +50,7 @@ export default function Search() {
             defaultValue={q}
             disabled={state !== "idle"}
             required
+            // eslint-disable-next-line jsx-a11y/no-autofocus -- search page primary input
             autoFocus
           />
           <button

--- a/src/app/routes/_shell.tsx
+++ b/src/app/routes/_shell.tsx
@@ -21,7 +21,7 @@ import { AddIcon } from "~/icons/addIcon"
 import { getCategories } from "~/data/categories"
 import { getDownloadClientFiles } from "~/data/downloadClient"
 
-export const action = (async ({ request }) => {
+export const action = (async () => {
   void restartAmule().catch(() => {})
   return null
 }) satisfies ActionFunction
@@ -156,7 +156,14 @@ export default function Layout() {
       <div
         data-hidden={menuHidden}
         className="fixed left-0 top-0 z-30 hidden h-full w-full backdrop-blur-sm data-[hidden=false]:block sm:data-[hidden=false]:hidden"
+        role="button"
+        tabIndex={0}
         onClick={() => setMenuHidden(true)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            setMenuHidden(true)
+          }
+        }}
       ></div>
       <nav
         className="fixed top-[60px] z-40 flex h-[calc(100%-60px)] w-[250px] flex-col bg-neutral-800 max-sm:transition-transform max-sm:data-[hidden=true]:-translate-x-full"

--- a/src/app/routes/_shell.tsx
+++ b/src/app/routes/_shell.tsx
@@ -153,18 +153,19 @@ export default function Layout() {
           </fetcher.Form>
         </div>
       </header>
-      <div
+      <button
+        type="button"
+        aria-label="Close navigation menu"
         data-hidden={menuHidden}
-        className="fixed left-0 top-0 z-30 hidden h-full w-full backdrop-blur-sm data-[hidden=false]:block sm:data-[hidden=false]:hidden"
-        role="button"
-        tabIndex={0}
+        className="fixed left-0 top-0 z-30 hidden h-full w-full border-0 bg-transparent p-0 backdrop-blur-sm data-[hidden=false]:block sm:data-[hidden=false]:hidden"
         onClick={() => setMenuHidden(true)}
         onKeyDown={(event) => {
           if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault()
             setMenuHidden(true)
           }
         }}
-      ></div>
+      />
       <nav
         className="fixed top-[60px] z-40 flex h-[calc(100%-60px)] w-[250px] flex-col bg-neutral-800 max-sm:transition-transform max-sm:data-[hidden=true]:-translate-x-full"
         data-hidden={menuHidden}

--- a/src/app/routes/api.tsx
+++ b/src/app/routes/api.tsx
@@ -38,6 +38,7 @@ async function handleTorznabRequest(request: Request) {
 }
 
 function caps(_url: URL) {
+  void _url
   return `
 <caps xmlns:torznab="http://torznab.com/schemas/2015/feed">
   <server version="1.0" title="eMulerr" strapline="eMulerr" />

--- a/src/app/routes/api.v2.app.preferences.tsx
+++ b/src/app/routes/api.v2.app.preferences.tsx
@@ -1,19 +1,7 @@
 import { LoaderFunction, json } from "@remix-run/node"
-import {
-  COMPLETED_COMPAT_RATIO,
-  QBITTORRENT_SAVE_PATH,
-} from "~/utils/qbittorrentTorrentResponse"
+import { QBITTORRENT_APP_PREFERENCES } from "~/utils/qbittorrentTorrentResponse"
 
 export const loader = (() =>
-  json({
-    save_path: QBITTORRENT_SAVE_PATH,
-    temp_path_enabled: true,
-    temp_path: "/downloads/incomplete",
-    create_subfolder_enabled: false,
-    max_ratio_enabled: true,
-    max_ratio: COMPLETED_COMPAT_RATIO,
-    max_seeding_time_enabled: true,
-    max_seeding_time: 86400,
-  })) satisfies LoaderFunction
+  json(QBITTORRENT_APP_PREFERENCES)) satisfies LoaderFunction
 
 export const action = loader

--- a/src/app/routes/api.v2.app.preferences.tsx
+++ b/src/app/routes/api.v2.app.preferences.tsx
@@ -1,15 +1,19 @@
 import { LoaderFunction, json } from "@remix-run/node"
+import {
+  COMPLETED_COMPAT_RATIO,
+  QBITTORRENT_SAVE_PATH,
+} from "~/utils/qbittorrentTorrentResponse"
 
 export const loader = (() =>
   json({
-    save_path: "/downloads/complete",
+    save_path: QBITTORRENT_SAVE_PATH,
     temp_path_enabled: true,
     temp_path: "/downloads/incomplete",
     create_subfolder_enabled: false,
     max_ratio_enabled: true,
-    max_ratio: 0,
+    max_ratio: COMPLETED_COMPAT_RATIO,
     max_seeding_time_enabled: true,
-    max_seeding_time: 0,
+    max_seeding_time: 86400,
   })) satisfies LoaderFunction
 
 export const action = loader

--- a/src/app/routes/api.v2.app.version.tsx
+++ b/src/app/routes/api.v2.app.version.tsx
@@ -1,0 +1,11 @@
+import { LoaderFunction } from "@remix-run/node"
+
+export const loader = (() =>
+  new Response(`v4.5.5`, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain",
+      "X-Content-Type-Options": "nosniff",
+      "Cache-Control": "public, max-age=0",
+    },
+  })) satisfies LoaderFunction

--- a/src/app/routes/api.v2.torrents.add.tsx
+++ b/src/app/routes/api.v2.torrents.add.tsx
@@ -5,6 +5,7 @@ import {
   parseSyntheticMagnetLink,
 } from "~/utils/qbittorrentMagnet"
 import { logger } from "~/utils/logger"
+import { parseTorrentAddOptions } from "~/utils/qbittorrentTorrentAdd"
 
 async function readTorrentAddFormData(request: Request): Promise<FormData> {
   try {
@@ -31,10 +32,7 @@ export const action = (async ({ request }) => {
   }
 
   const urlsRaw = formData.get("urls")?.toString()
-  const category = formData.get("category")?.toString() ?? ""
-  const paused =
-    formData.get("paused")?.toString().trim().toLowerCase() === "true" ||
-    formData.get("stopped")?.toString().trim().toLowerCase() === "true"
+  const { category, paused } = parseTorrentAddOptions(formData)
 
   if (!urlsRaw?.trim()) {
     return new Response("Missing urls parameter", { status: 400 })

--- a/src/app/routes/api.v2.torrents.add.tsx
+++ b/src/app/routes/api.v2.torrents.add.tsx
@@ -1,24 +1,68 @@
 import { ActionFunction, json } from "@remix-run/node"
 import { download } from "~/data/downloadClient"
-import { fromMagnetLink } from "~/links"
+import {
+  MagnetParseError,
+  parseSyntheticMagnetLink,
+} from "~/utils/qbittorrentMagnet"
 import { logger } from "~/utils/logger"
 
+async function readTorrentAddFormData(request: Request): Promise<FormData> {
+  try {
+    return await request.formData()
+  } catch {
+    return new FormData()
+  }
+}
+
 export const action = (async ({ request }) => {
-  logger.debug("URL", request.url)
-  const formData = await request.formData()
-  const urls = formData.get("urls")?.toString()
-  const category = formData.get("category")?.toString()
+  const url = new URL(request.url)
+  logger.debug("Path", url.pathname)
 
-  if (!urls) {
-    throw new Error("No URL to download")
+  const formData = await readTorrentAddFormData(request)
+
+  if (formData.has("torrents") || formData.has("torrents0")) {
+    return new Response(
+      "BitTorrent .torrent file uploads are unsupported; use eMulerr synthetic magnets",
+      {
+        status: 415,
+        headers: { "Content-Type": "text/plain" },
+      }
+    )
   }
 
-  if (!category) {
-    throw new Error("No download category")
+  const urlsRaw = formData.get("urls")?.toString()
+  const category = formData.get("category")?.toString() ?? ""
+  const paused =
+    formData.get("paused")?.toString().trim().toLowerCase() === "true" ||
+    formData.get("stopped")?.toString().trim().toLowerCase() === "true"
+
+  if (!urlsRaw?.trim()) {
+    return new Response("Missing urls parameter", { status: 400 })
   }
 
-  const { hash, name, size } = fromMagnetLink(urls)
-  await download(hash, name, size, category)
+  const magnets = urlsRaw
+    .split("\n")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+
+  const parsedMagnets = []
+  for (const magnet of magnets) {
+    try {
+      parsedMagnets.push(parseSyntheticMagnetLink(magnet))
+    } catch (error) {
+      const message =
+        error instanceof MagnetParseError
+          ? error.message
+          : "Invalid magnet link"
+      return new Response(message, { status: 400 })
+    }
+  }
+
+  for (const magnet of parsedMagnets) {
+    await download(magnet.hash, magnet.name, magnet.size, category, {
+      paused,
+    })
+  }
 
   return json({})
 }) satisfies ActionFunction

--- a/src/app/routes/api.v2.torrents.createCategory.tsx
+++ b/src/app/routes/api.v2.torrents.createCategory.tsx
@@ -3,7 +3,7 @@ import { createCategory } from "~/data/categories"
 import { logger } from "~/utils/logger"
 
 export const action = (async ({ request }) => {
-  logger.debug("URL", request.url)
+  logger.debug("Path", new URL(request.url).pathname)
   const formData = await request.formData()
   const category = formData.get("category")?.toString()
 

--- a/src/app/routes/api.v2.torrents.delete.tsx
+++ b/src/app/routes/api.v2.torrents.delete.tsx
@@ -1,20 +1,23 @@
 import { ActionFunction, json } from "@remix-run/node"
-import { remove } from "~/data/downloadClient"
-import { skipFalsy } from "~/utils/array"
+import {
+  removeTorrents,
+  selectionFromParsedHashes,
+} from "~/data/downloadClient"
+import { parseTorrentHashesFromFormData } from "~/utils/qbittorrentHash"
+import { parseQbittorrentBoolean } from "~/utils/qbittorrentBoolean"
 import { logger } from "~/utils/logger"
 
 export const action = (async ({ request }) => {
-  logger.debug("URL", request.url)
-  const formData = await request.formData()
-  const hashes = formData
-    .get("hashes")
-    ?.toString()
-    ?.toUpperCase()
-    ?.split("|")
-    .filter(skipFalsy)
+  const url = new URL(request.url)
+  logger.debug("Path", url.pathname)
 
-  if (hashes?.length) {
-    await remove(hashes)
+  const formData = await request.formData()
+  const parsed = parseTorrentHashesFromFormData(formData)
+  const selection = selectionFromParsedHashes(parsed)
+  const deleteFiles = parseQbittorrentBoolean(formData.get("deleteFiles"))
+
+  if (selection) {
+    await removeTorrents(selection, deleteFiles)
   }
 
   return json({})

--- a/src/app/routes/api.v2.torrents.files.tsx
+++ b/src/app/routes/api.v2.torrents.files.tsx
@@ -1,0 +1,23 @@
+import { LoaderFunction, json } from "@remix-run/node"
+import { getApiVisibleFileByHash } from "~/data/downloadClient"
+import { buildQbittorrentTorrentFile } from "~/utils/qbittorrentTorrentResponse"
+import { logger } from "~/utils/logger"
+
+export const loader = (async ({ request }) => {
+  const url = new URL(request.url)
+  logger.debug("Path", url.pathname)
+
+  const hash = url.searchParams.get("hash")
+  if (!hash) {
+    return new Response("Missing hash parameter", { status: 400 })
+  }
+
+  const file = await getApiVisibleFileByHash(hash)
+  if (!file) {
+    return new Response("Not Found", { status: 404 })
+  }
+
+  return json([buildQbittorrentTorrentFile(file)])
+}) satisfies LoaderFunction
+
+export const action = loader

--- a/src/app/routes/api.v2.torrents.info.tsx
+++ b/src/app/routes/api.v2.torrents.info.tsx
@@ -1,7 +1,10 @@
 import { LoaderFunction, json } from "@remix-run/node"
 import { getDownloadClientFiles } from "~/data/downloadClient"
 import { buildQbittorrentTorrentInfo } from "~/utils/qbittorrentTorrentResponse"
-import { parseQbittorrentHashSelection } from "~/utils/qbittorrentHash"
+import {
+  hashSelectionMatchesFile,
+  parseQbittorrentHashQuery,
+} from "~/utils/qbittorrentHash"
 import { logger } from "~/utils/logger"
 
 export const loader = (async ({ request }) => {
@@ -9,7 +12,8 @@ export const loader = (async ({ request }) => {
   logger.debug("Path", url.pathname)
 
   const category = url.searchParams.get("category")
-  const hashSelection = parseQbittorrentHashSelection(
+  const hashSelection = parseQbittorrentHashQuery(
+    url.searchParams.has("hashes"),
     url.searchParams.get("hashes")
   )
   const files = await getDownloadClientFiles()
@@ -21,14 +25,7 @@ export const loader = (async ({ request }) => {
           return false
         }
 
-        if (hashSelection.kind === "hashes") {
-          const wanted = new Set(
-            hashSelection.hashes.map((hash) => hash.toUpperCase())
-          )
-          return wanted.has(file.hash.toUpperCase())
-        }
-
-        return true
+        return hashSelectionMatchesFile(hashSelection, file.hash)
       })
       .map((file) => buildQbittorrentTorrentInfo(file))
       .filter((entry) => entry !== null)

--- a/src/app/routes/api.v2.torrents.info.tsx
+++ b/src/app/routes/api.v2.torrents.info.tsx
@@ -1,66 +1,38 @@
 import { LoaderFunction, json } from "@remix-run/node"
-import { amuleGetDownloads } from "amule/amule"
-import { existsSync } from "fs"
 import { getDownloadClientFiles } from "~/data/downloadClient"
+import { buildQbittorrentTorrentInfo } from "~/utils/qbittorrentTorrentResponse"
+import { parseQbittorrentHashSelection } from "~/utils/qbittorrentHash"
 import { logger } from "~/utils/logger"
 
 export const loader = (async ({ request }) => {
-  logger.debug("URL", request.url)
   const url = new URL(request.url)
+  logger.debug("Path", url.pathname)
+
   const category = url.searchParams.get("category")
+  const hashSelection = parseQbittorrentHashSelection(
+    url.searchParams.get("hashes")
+  )
   const files = await getDownloadClientFiles()
 
-  return json([
-    ...files
-      .filter((d) => {
-        return !category || d.meta?.category === category
+  return json(
+    files
+      .filter((file) => {
+        if (category !== null && (file.meta?.category ?? "") !== category) {
+          return false
+        }
+
+        if (hashSelection.kind === "hashes") {
+          const wanted = new Set(
+            hashSelection.hashes.map((hash) => hash.toUpperCase())
+          )
+          return wanted.has(file.hash.toUpperCase())
+        }
+
+        return true
       })
-      .map((f) => ({
-        // qBittorrent structure
-        hash: f.hash,
-        name: f.name,
-        size: f.size,
-        size_done: f.size_done,
-        progress:
-          f.progress === 1 ? 1 : Math.min(0.999, Math.max(f.progress, 0.001)),
-        dlspeed: f.speed,
-        eta: f.eta,
-        state: statusToQbittorrentState(f.status_str),
-        content_path: contentPath(f.name),
-        category: f.meta?.category,
-      })),
-  ])
+      .map((file) => buildQbittorrentTorrentInfo(file))
+      .filter((entry) => entry !== null)
+  )
 }) satisfies LoaderFunction
 
 export const action = loader
-
-function contentPath(name: string) {
-  if (existsSync(`/downloads/complete/${name}`)) {
-    return `/downloads/complete/${name}`
-  }
-
-  if (existsSync(`/tmp/shared/${name}`)) {
-    return `/tmp/shared/${name}`
-  }
-
-  return undefined
-}
-
-function statusToQbittorrentState(
-  status: Awaited<ReturnType<typeof amuleGetDownloads>>[0]["status_str"]
-) {
-  switch (status) {
-    case "downloading":
-      return "downloading"
-    case "downloaded":
-      return "pausedUP"
-    case "stalled":
-      return "stalledDL"
-    case "error":
-      return "error"
-    case "completing":
-      return "moving"
-    case "stopped":
-      return "pausedDL"
-  }
-}

--- a/src/app/routes/api.v2.torrents.pause.tsx
+++ b/src/app/routes/api.v2.torrents.pause.tsx
@@ -1,0 +1,11 @@
+import { ActionFunction, LoaderFunction } from "@remix-run/node"
+import {
+  handleTorrentStateAction,
+  rejectTorrentStateGet,
+} from "~/utils/qbittorrentTorrentState"
+
+export const loader = (() =>
+  rejectTorrentStateGet()) satisfies LoaderFunction
+
+export const action = (async ({ request }) =>
+  handleTorrentStateAction(request, "pause")) satisfies ActionFunction

--- a/src/app/routes/api.v2.torrents.properties.tsx
+++ b/src/app/routes/api.v2.torrents.properties.tsx
@@ -1,6 +1,6 @@
 import { LoaderFunction, json } from "@remix-run/node"
 import { getApiVisibleFileByHash } from "~/data/downloadClient"
-import { QBITTORRENT_SAVE_PATH } from "~/utils/qbittorrentTorrentResponse"
+import { buildQbittorrentTorrentProperties } from "~/utils/qbittorrentTorrentResponse"
 import { logger } from "~/utils/logger"
 
 export const loader = (async ({ request }) => {
@@ -17,32 +17,7 @@ export const loader = (async ({ request }) => {
     return new Response("Not Found", { status: 404 })
   }
 
-  return json({
-    save_path: QBITTORRENT_SAVE_PATH,
-    creation_date: 0,
-    piece_size: 0,
-    comment: "",
-    total_wasted: 0,
-    total_uploaded: 0,
-    total_uploaded_session: 0,
-    total_downloaded: file.size_done,
-    total_downloaded_session: file.size_done,
-    up_limit: -1,
-    dl_limit: -1,
-    time_elapsed: 0,
-    nb_connections: 0,
-    nb_connections_limit: 100,
-    share_ratio: file.progress >= 1 ? 1 : 0,
-    addition_date: file.meta?.addedOn ?? 0,
-    completion_date: file.meta?.completionOn ?? 0,
-    created_by: "eMulerr",
-    dl_speed_avg: file.speed ?? 0,
-    dl_speed: file.speed ?? 0,
-    eta: file.eta,
-    last_seen: 0,
-    peers: 0,
-    seeds: 0,
-  })
+  return json(buildQbittorrentTorrentProperties(file))
 }) satisfies LoaderFunction
 
 export const action = loader

--- a/src/app/routes/api.v2.torrents.properties.tsx
+++ b/src/app/routes/api.v2.torrents.properties.tsx
@@ -1,0 +1,48 @@
+import { LoaderFunction, json } from "@remix-run/node"
+import { getApiVisibleFileByHash } from "~/data/downloadClient"
+import { QBITTORRENT_SAVE_PATH } from "~/utils/qbittorrentTorrentResponse"
+import { logger } from "~/utils/logger"
+
+export const loader = (async ({ request }) => {
+  const url = new URL(request.url)
+  logger.debug("Path", url.pathname)
+
+  const hash = url.searchParams.get("hash")
+  if (!hash) {
+    return new Response("Missing hash parameter", { status: 400 })
+  }
+
+  const file = await getApiVisibleFileByHash(hash)
+  if (!file) {
+    return new Response("Not Found", { status: 404 })
+  }
+
+  return json({
+    save_path: QBITTORRENT_SAVE_PATH,
+    creation_date: 0,
+    piece_size: 0,
+    comment: "",
+    total_wasted: 0,
+    total_uploaded: 0,
+    total_uploaded_session: 0,
+    total_downloaded: file.size_done,
+    total_downloaded_session: file.size_done,
+    up_limit: -1,
+    dl_limit: -1,
+    time_elapsed: 0,
+    nb_connections: 0,
+    nb_connections_limit: 100,
+    share_ratio: file.progress >= 1 ? 1 : 0,
+    addition_date: file.meta?.addedOn ?? 0,
+    completion_date: file.meta?.completionOn ?? 0,
+    created_by: "eMulerr",
+    dl_speed_avg: file.speed ?? 0,
+    dl_speed: file.speed ?? 0,
+    eta: file.eta,
+    last_seen: 0,
+    peers: 0,
+    seeds: 0,
+  })
+}) satisfies LoaderFunction
+
+export const action = loader

--- a/src/app/routes/api.v2.torrents.resume.tsx
+++ b/src/app/routes/api.v2.torrents.resume.tsx
@@ -1,0 +1,11 @@
+import { ActionFunction, LoaderFunction } from "@remix-run/node"
+import {
+  handleTorrentStateAction,
+  rejectTorrentStateGet,
+} from "~/utils/qbittorrentTorrentState"
+
+export const loader = (() =>
+  rejectTorrentStateGet()) satisfies LoaderFunction
+
+export const action = (async ({ request }) =>
+  handleTorrentStateAction(request, "resume")) satisfies ActionFunction

--- a/src/app/routes/api.v2.torrents.setCategory.tsx
+++ b/src/app/routes/api.v2.torrents.setCategory.tsx
@@ -1,26 +1,27 @@
 import { ActionFunction, json } from "@remix-run/node"
-import { setCategory } from "~/data/downloadClient"
-import { skipFalsy } from "~/utils/array"
+import {
+  resolveApiVisibleHashes,
+  selectionFromParsedHashes,
+  setCategoryForKnownHashes,
+} from "~/data/downloadClient"
+import { parseTorrentHashesFromFormData } from "~/utils/qbittorrentHash"
 import { logger } from "~/utils/logger"
 
 export const action = (async ({ request }) => {
-  logger.debug("URL", request.url)
-  const formData = await request.formData()
-  const hashes = formData
-    .get("hashes")
-    ?.toString()
-    ?.toUpperCase()
-    ?.split("|")
-    .filter(skipFalsy)
-  const category = formData.get("category")?.toString()
+  const url = new URL(request.url)
+  logger.debug("Path", url.pathname)
 
-  if (category && hashes?.length) {
-    await Promise.all(
-      hashes.map(async (hash) => {
-        setCategory(hash, category)
-      })
-    )
+  const formData = await request.formData()
+  const parsed = parseTorrentHashesFromFormData(formData)
+  const selection = selectionFromParsedHashes(parsed)
+  const category = formData.get("category")
+
+  if (typeof category !== "string" || !selection) {
+    return json({})
   }
+
+  const knownHashes = await resolveApiVisibleHashes(selection)
+  setCategoryForKnownHashes(knownHashes, category)
 
   return json({})
 }) satisfies ActionFunction

--- a/src/app/routes/api.v2.torrents.start.tsx
+++ b/src/app/routes/api.v2.torrents.start.tsx
@@ -1,0 +1,11 @@
+import { ActionFunction, LoaderFunction } from "@remix-run/node"
+import {
+  handleTorrentStateAction,
+  rejectTorrentStateGet,
+} from "~/utils/qbittorrentTorrentState"
+
+export const loader = (() =>
+  rejectTorrentStateGet()) satisfies LoaderFunction
+
+export const action = (async ({ request }) =>
+  handleTorrentStateAction(request, "resume")) satisfies ActionFunction

--- a/src/app/routes/api.v2.torrents.stop.tsx
+++ b/src/app/routes/api.v2.torrents.stop.tsx
@@ -1,0 +1,11 @@
+import { ActionFunction, LoaderFunction } from "@remix-run/node"
+import {
+  handleTorrentStateAction,
+  rejectTorrentStateGet,
+} from "~/utils/qbittorrentTorrentState"
+
+export const loader = (() =>
+  rejectTorrentStateGet()) satisfies LoaderFunction
+
+export const action = (async ({ request }) =>
+  handleTorrentStateAction(request, "pause")) satisfies ActionFunction

--- a/src/app/routes/health.tsx
+++ b/src/app/routes/health.tsx
@@ -1,6 +1,6 @@
 import { LoaderFunction, json } from "@remix-run/node"
 
-export const loader = (async ({ request }) => {
+export const loader = (async () => {
   return json({ ok: 1 })
 }) satisfies LoaderFunction
 

--- a/src/app/routes/revalidate.tsx
+++ b/src/app/routes/revalidate.tsx
@@ -1,6 +1,6 @@
 import { LoaderFunction } from "@remix-run/node"
 
-export const loader = (async ({ request }) => {
+export const loader = (async () => {
   return null
 }) satisfies LoaderFunction
 

--- a/src/app/utils/array.ts
+++ b/src/app/utils/array.ts
@@ -4,7 +4,7 @@ export const groupBy = <T, K extends string>(
 ) =>
     array.reduce(
         (acc, value, index, array) => {
-            ; (acc[predicate(value, index, array)] ||= []).push(value)
+             (acc[predicate(value, index, array)] ||= []).push(value)
             return acc
         },
         {} as Record<K, T[]>

--- a/src/app/utils/generators.ts
+++ b/src/app/utils/generators.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 export type AsyncGeneratorReturnType<T extends (...args: any) => any> = ReturnType<T> extends AsyncGenerator<any, infer R, any> ? R : never
 
 export async function yieldAll<Y, R>(it: AsyncGenerator<Y, R, any>, callback?: (yielded: Y) => void) {

--- a/src/app/utils/indexers.ts
+++ b/src/app/utils/indexers.ts
@@ -1,18 +1,10 @@
 import { skipFalsy } from "./array"
-import { encode } from "html-entities"
-import { buildRFC822Date } from "./time"
 import { logger } from "./logger"
 import { readableSize } from "./math"
 import { searchAndWaitForResults } from "~/data/search"
+import { hasAllowedExtension } from "./torznabFeed"
 
-const VIDEO_EXTENSIONS = ["mp4", "mkv", "avi", "wmv", "mpeg", "mpg"]
-const PUBLICATION_EXTENSIONS = ["pdf", "epub", "mobi", "azw3", "cbz", "cbr", "zip", "rar"]
-const TORZNAB_EXTENSIONS = [...VIDEO_EXTENSIONS, ...PUBLICATION_EXTENSIONS]
-
-function hasAllowedExtension(filename: string) {
-  const lower = filename.toLowerCase()
-  return TORZNAB_EXTENSIONS.some((ext) => lower.endsWith(`.${ext}`))
-}
+export { hasAllowedExtension, itemsResponse } from "./torznabFeed"
 
 export const fakeItem = {
   name: "FAKE",
@@ -34,54 +26,29 @@ export const emptyResponse = () => `
 
 export async function search(q: string) {
   const searchResults = await searchAndWaitForResults(q)
-  const { allowed, skipped } = searchResults.reduce((prev, curr) => {
-    if (hasAllowedExtension(curr.name)) {
-      prev.allowed.push(curr)
-    } else {
-      prev.skipped.push(curr)
-    }
-    return prev
-  }, { allowed: [] as typeof searchResults, skipped: [] as typeof searchResults })
+  const { allowed, skipped } = searchResults.reduce(
+    (prev, curr) => {
+      if (hasAllowedExtension(curr.name)) {
+        prev.allowed.push(curr)
+      } else {
+        prev.skipped.push(curr)
+      }
+      return prev
+    },
+    { allowed: [] as typeof searchResults, skipped: [] as typeof searchResults }
+  )
 
   if (skipped.length > 0) {
-    logger.debug(`${skipped.length} results excluded with unknown file extensions:`)
-    skipped.forEach(r => {
+    logger.debug(
+      `${skipped.length} results excluded with unknown file extensions:`
+    )
+    skipped.forEach((r) => {
       logger.debug(`\t- ${r.name} (${readableSize(r.size)})`)
     })
   }
 
   return allowed
 }
-
-export const itemsResponse = (
-  searchResults: Awaited<ReturnType<typeof search>>,
-  categories: number[]
-) => `
-  <rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
-    <channel>
-      <torznab:response offset="0" total="${searchResults.length}"/>
-      ${searchResults.map(
-  (item) => `
-          <item>
-            <title>${encode(item.name)}</title>
-            <guid>${item.hash}-${encode(item.name)}</guid>
-            <link>${encode(item.magnetLink)}</link>
-            <pubDate>${buildRFC822Date(new Date())}</pubDate>
-            <enclosure url="${encode(item.magnetLink)}" length="${item.size}" type="application/x-bittorrent" />
-            <torznab:attr name="magneturl" value="${encode(item.magnetLink)}" />
-            <torznab:attr name="size" value="${item.size}" />
-            ${categories.map((c) => `<torznab:attr name="category" value="${c}" />`).join("")}
-            <torznab:attr name="seeders" value="${item.sources}" />
-            <torznab:attr name="downloadvolumefactor" value="0" />
-            <torznab:attr name="uploadvolumefactor" value="0" />
-            <torznab:attr name="minimumratio" value="0" />
-            <torznab:attr name="minimumseedtime" value="0" />
-            <torznab:attr name="tag" value="freeleech" />
-          </item>`
-)}
-    </channel>
-  </rss>
-  `
 
 export function group<T>(
   arr: T[],
@@ -94,22 +61,22 @@ export function group<T>(
     operator === "OR"
       ? arr.join(` ${operator} `)
       : arr
-        .sort(
-          // move parenthesis to the end
-          (a, b) =>
-            (typeof a === "string" && a.startsWith("(") ? 1 : 0) -
-            (typeof b === "string" && b.startsWith("(") ? 1 : 0)
-        )
-        .reduce(
-          (prev, curr) =>
-            prev === ""
-              ? `${curr}`
-              : prev.endsWith(")") ||
-                (typeof curr === "string" && curr.startsWith("("))
-                ? `${prev} AND ${curr}`
-                : `${prev} ${curr}`,
-          ""
-        )
+          .sort(
+            // move parenthesis to the end
+            (a, b) =>
+              (typeof a === "string" && a.startsWith("(") ? 1 : 0) -
+              (typeof b === "string" && b.startsWith("(") ? 1 : 0)
+          )
+          .reduce(
+            (prev, curr) =>
+              prev === ""
+                ? `${curr}`
+                : prev.endsWith(")") ||
+                    (typeof curr === "string" && curr.startsWith("("))
+                  ? `${prev} AND ${curr}`
+                  : `${prev} ${curr}`,
+            ""
+          )
 
   if (!parenthesis) {
     return joined

--- a/src/app/utils/indexers.ts
+++ b/src/app/utils/indexers.ts
@@ -5,6 +5,15 @@ import { logger } from "./logger"
 import { readableSize } from "./math"
 import { searchAndWaitForResults } from "~/data/search"
 
+const VIDEO_EXTENSIONS = ["mp4", "mkv", "avi", "wmv", "mpeg", "mpg"]
+const PUBLICATION_EXTENSIONS = ["pdf", "epub", "mobi", "azw3", "cbz", "cbr", "zip", "rar"]
+const TORZNAB_EXTENSIONS = [...VIDEO_EXTENSIONS, ...PUBLICATION_EXTENSIONS]
+
+function hasAllowedExtension(filename: string) {
+  const lower = filename.toLowerCase()
+  return TORZNAB_EXTENSIONS.some((ext) => lower.endsWith(`.${ext}`))
+}
+
 export const fakeItem = {
   name: "FAKE",
   short_name: "FAKE",
@@ -26,7 +35,7 @@ export const emptyResponse = () => `
 export async function search(q: string) {
   const searchResults = await searchAndWaitForResults(q)
   const { allowed, skipped } = searchResults.reduce((prev, curr) => {
-    if (["mp4", "mkv", "avi", "wmv", "mpeg", "mpg"].some((ext) => curr.name.endsWith(`.${ext}`))) {
+    if (hasAllowedExtension(curr.name)) {
       prev.allowed.push(curr)
     } else {
       prev.skipped.push(curr)
@@ -56,8 +65,10 @@ export const itemsResponse = (
           <item>
             <title>${encode(item.name)}</title>
             <guid>${item.hash}-${encode(item.name)}</guid>
+            <link>${encode(item.magnetLink)}</link>
             <pubDate>${buildRFC822Date(new Date())}</pubDate>
             <enclosure url="${encode(item.magnetLink)}" length="${item.size}" type="application/x-bittorrent" />
+            <torznab:attr name="magneturl" value="${encode(item.magnetLink)}" />
             <torznab:attr name="size" value="${item.size}" />
             ${categories.map((c) => `<torznab:attr name="category" value="${c}" />`).join("")}
             <torznab:attr name="seeders" value="${item.sources}" />

--- a/src/app/utils/jsonDb.ts
+++ b/src/app/utils/jsonDb.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { writeFile, chown, mkdir, rename, rm } from "node:fs/promises"
 import { readFileSync, existsSync } from "node:fs"
 import { dirname } from "path"
@@ -27,7 +28,9 @@ export function createJsonDb<Schema>(
     } else if (state.data && initialState instanceof Set && Array.isArray(state.data)) {
       state.data = new Set(state.data) as Schema
     }
-  } catch { }
+  } catch {
+    // Ignore unreadable metadata files and fall back to defaults.
+  }
 
   state.data = initializer ? initializer(state.data) : state.data
 

--- a/src/app/utils/logger.ts
+++ b/src/app/utils/logger.ts
@@ -23,7 +23,9 @@ declare global {
   /**
    * Default log level is "debug"
    */
+  // eslint-disable-next-line no-var -- global augmentation requires var
   var logLevel: LogLevelValue | undefined
+  // eslint-disable-next-line no-var -- global augmentation requires var
   var originalConsole: Console
 }
 

--- a/src/app/utils/memoize.ts
+++ b/src/app/utils/memoize.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import ExpiryMap from "expiry-map"
 import memoize from "memoize"
 import pMemoize, { AnyAsyncFunction } from "p-memoize"

--- a/src/app/utils/naming.ts
+++ b/src/app/utils/naming.ts
@@ -24,7 +24,7 @@ export function sanitizeQuery(q: string | undefined | null) {
   }
 
   return sanitizeUnicode(q)
-    .replace(/[^\w \(\)'-]/g, " ")
+    .replace(/[^\w ()'-]/g, " ")
     .replace(/ +/g, " ")
     .trim()
 }
@@ -35,7 +35,7 @@ export function sanitizeFilename(str: string) {
   str = sanitizeUnicode(str)
 
   // fix utf8 decoding artifacts
-  while (true) {
+  for (;;) {
     try {
       const nstr = decodeURIComponent(escape(str));
       if (nstr === str) {

--- a/src/app/utils/qbittorrentBoolean.test.ts
+++ b/src/app/utils/qbittorrentBoolean.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { parseQbittorrentBoolean } from "./qbittorrentBoolean.ts"
+
+describe("qbittorrentBoolean", () => {
+  it("parses qBittorrent deleteFiles values", () => {
+    assert.equal(parseQbittorrentBoolean("true"), true)
+    assert.equal(parseQbittorrentBoolean('"true"'), false)
+    assert.equal(parseQbittorrentBoolean("false"), false)
+    assert.equal(parseQbittorrentBoolean(null), false)
+  })
+})

--- a/src/app/utils/qbittorrentBoolean.ts
+++ b/src/app/utils/qbittorrentBoolean.ts
@@ -1,0 +1,10 @@
+export function parseQbittorrentBoolean(
+  value: FormDataEntryValue | null
+): boolean {
+  if (value === null) {
+    return false
+  }
+
+  const normalized = String(value).trim().toLowerCase()
+  return normalized === "true" || normalized === "1" || normalized === "yes"
+}

--- a/src/app/utils/qbittorrentDeletion.test.ts
+++ b/src/app/utils/qbittorrentDeletion.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import {
+  COMPLETE_DOWNLOAD_ROOT,
+  INCOMPLETE_DOWNLOAD_ROOT,
+  SHARED_DOWNLOAD_ROOT,
+} from "./qbittorrentPathSafety.ts"
+import {
+  resolveDeletionFilePath,
+  resolveDeletionTargetRoots,
+} from "./qbittorrentDeletion.ts"
+
+describe("qbittorrentDeletion", () => {
+  it("targets completed files in complete/shared roots only", () => {
+    assert.deepEqual(resolveDeletionTargetRoots(true), [
+      COMPLETE_DOWNLOAD_ROOT,
+      SHARED_DOWNLOAD_ROOT,
+    ])
+    assert.deepEqual(resolveDeletionTargetRoots(false), [
+      INCOMPLETE_DOWNLOAD_ROOT,
+    ])
+  })
+
+  it("deletes only the first matching trusted path", () => {
+    const completePath = `${COMPLETE_DOWNLOAD_ROOT}/book.epub`
+    const sharedPath = `${SHARED_DOWNLOAD_ROOT}/book.epub`
+    const existsAt = (path: string) =>
+      path === completePath || path === sharedPath
+
+    assert.equal(
+      resolveDeletionFilePath("book.epub", true, existsAt),
+      completePath
+    )
+  })
+
+  it("preserves unrelated same-named files in other roots", () => {
+    const sharedPath = `${SHARED_DOWNLOAD_ROOT}/book.epub`
+    const existsAt = (path: string) => path === sharedPath
+
+    assert.equal(
+      resolveDeletionFilePath("book.epub", true, existsAt),
+      sharedPath
+    )
+    assert.equal(
+      resolveDeletionFilePath("../secret.epub", true, () => true),
+      null
+    )
+  })
+})

--- a/src/app/utils/qbittorrentDeletion.test.ts
+++ b/src/app/utils/qbittorrentDeletion.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   resolveDeletionFilePath,
   resolveDeletionTargetRoots,
+  unlinkExistingFile,
 } from "./qbittorrentDeletion.ts"
 
 describe("qbittorrentDeletion", () => {
@@ -45,5 +46,38 @@ describe("qbittorrentDeletion", () => {
       resolveDeletionFilePath("../secret.epub", true, () => true),
       null
     )
+  })
+
+  describe("unlinkExistingFile", () => {
+    it("treats ENOENT as already deleted", async () => {
+      const enoent = Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+      let called = false
+      await unlinkExistingFile("/downloads/complete/missing.epub", async () => {
+        called = true
+        throw enoent
+      })
+      assert.equal(called, true)
+    })
+
+    it("propagates non-ENOENT unlink errors", async () => {
+      const eacces = Object.assign(new Error("EACCES"), { code: "EACCES" })
+      await assert.rejects(
+        unlinkExistingFile("/downloads/complete/locked.epub", async () => {
+          throw eacces
+        }),
+        /EACCES/
+      )
+    })
+
+    it("completes when unlink succeeds", async () => {
+      let removed: string | undefined
+      await unlinkExistingFile(
+        "/downloads/complete/book.epub",
+        async (path) => {
+          removed = path
+        }
+      )
+      assert.equal(removed, "/downloads/complete/book.epub")
+    })
   })
 })

--- a/src/app/utils/qbittorrentDeletion.ts
+++ b/src/app/utils/qbittorrentDeletion.ts
@@ -1,0 +1,27 @@
+import {
+  COMPLETE_DOWNLOAD_ROOT,
+  INCOMPLETE_DOWNLOAD_ROOT,
+  resolveSafeFilePath,
+  SHARED_DOWNLOAD_ROOT,
+} from "~/utils/qbittorrentPathSafety"
+
+export function resolveDeletionTargetRoots(isCompleted: boolean): string[] {
+  return isCompleted
+    ? [COMPLETE_DOWNLOAD_ROOT, SHARED_DOWNLOAD_ROOT]
+    : [INCOMPLETE_DOWNLOAD_ROOT]
+}
+
+export function resolveDeletionFilePath(
+  fileName: string,
+  isCompleted: boolean,
+  existsAt: (path: string) => boolean
+): string | null {
+  for (const root of resolveDeletionTargetRoots(isCompleted)) {
+    const safePath = resolveSafeFilePath(root, fileName)
+    if (safePath && existsAt(safePath)) {
+      return safePath
+    }
+  }
+
+  return null
+}

--- a/src/app/utils/qbittorrentDeletion.ts
+++ b/src/app/utils/qbittorrentDeletion.ts
@@ -25,3 +25,18 @@ export function resolveDeletionFilePath(
 
   return null
 }
+
+export async function unlinkExistingFile(
+  targetPath: string,
+  unlinkFn: (path: string) => Promise<void>
+): Promise<void> {
+  try {
+    await unlinkFn(targetPath)
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return
+    }
+
+    throw error
+  }
+}

--- a/src/app/utils/qbittorrentHash.test.ts
+++ b/src/app/utils/qbittorrentHash.test.ts
@@ -2,12 +2,16 @@ import assert from "node:assert/strict"
 import { describe, it } from "node:test"
 import {
   externalToInternalEd2kHash,
+  hashSelectionMatchesFile,
   internalToExternalQbittorrentHash,
   normalizeInternalEd2kHash,
+  parseQbittorrentHashQuery,
   parseQbittorrentHashSelection,
+  selectionFromParsedHashes,
 } from "./qbittorrentHash.ts"
 
 const SAMPLE = "A1B2C3D4E5F6789012345678ABCDEF01"
+const UNKNOWN = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
 
 describe("qbittorrentHash", () => {
   it("normalizes internal hashes", () => {
@@ -35,8 +39,13 @@ describe("qbittorrentHash", () => {
     )
   })
 
-  it("parses hashes=all", () => {
+  it("distinguishes absent, empty, all, valid and invalid selections", () => {
+    assert.deepEqual(parseQbittorrentHashQuery(false, null), { kind: "absent" })
+    assert.deepEqual(parseQbittorrentHashQuery(true, ""), { kind: "empty" })
     assert.deepEqual(parseQbittorrentHashSelection("ALL"), { kind: "all" })
+    assert.deepEqual(parseQbittorrentHashSelection("not-a-hash"), {
+      kind: "invalid",
+    })
   })
 
   it("parses pipe-separated mixed-case hashes", () => {
@@ -49,7 +58,33 @@ describe("qbittorrentHash", () => {
     }
   })
 
-  it("rejects malformed selections", () => {
-    assert.deepEqual(parseQbittorrentHashSelection("not-a-hash"), { kind: "none" })
+  it("returns null selection for mutation no-ops", () => {
+    assert.equal(selectionFromParsedHashes({ kind: "absent" }), null)
+    assert.equal(selectionFromParsedHashes({ kind: "empty" }), null)
+    assert.equal(selectionFromParsedHashes({ kind: "invalid" }), null)
+    assert.equal(selectionFromParsedHashes({ kind: "all" }), "all")
+  })
+
+  it("filters info results by hash selection semantics", () => {
+    assert.equal(
+      hashSelectionMatchesFile({ kind: "absent" }, SAMPLE),
+      true
+    )
+    assert.equal(
+      hashSelectionMatchesFile({ kind: "invalid" }, SAMPLE),
+      false
+    )
+    assert.equal(
+      hashSelectionMatchesFile({ kind: "empty" }, SAMPLE),
+      false
+    )
+    assert.equal(
+      hashSelectionMatchesFile({ kind: "hashes", hashes: [SAMPLE] }, SAMPLE),
+      true
+    )
+    assert.equal(
+      hashSelectionMatchesFile({ kind: "hashes", hashes: [UNKNOWN] }, SAMPLE),
+      false
+    )
   })
 })

--- a/src/app/utils/qbittorrentHash.test.ts
+++ b/src/app/utils/qbittorrentHash.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict"
 import { describe, it } from "node:test"
+import base32 from "hi-base32"
 import {
+  compatibilityHashToInternalEd2kHash,
   externalToInternalEd2kHash,
   hashSelectionMatchesFile,
   internalToExternalQbittorrentHash,
@@ -13,6 +15,17 @@ import {
 
 const SAMPLE = "A1B2C3D4E5F6789012345678ABCDEF01"
 const UNKNOWN = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+
+const REPRODUCED_BASE32 = "3ZXWM66ZHIOH7FHJZXMKSJFAW4AAAAAA"
+const REPRODUCED_INTERNAL = "DE6F667BD93A1C7F94E9CDD8A924A0B7"
+const REPRODUCED_EXTERNAL = "de6f667bd93a1c7f94e9cdd8a924a0b700000000"
+
+function buildSyntheticBase32FromInternal(internalHex: string): string {
+  const hashBuffer = Buffer.from(internalHex, "hex")
+  const base32Buffer = Buffer.alloc(20, 0)
+  hashBuffer.copy(base32Buffer)
+  return base32.encode(base32Buffer).toUpperCase()
+}
 
 describe("qbittorrentHash", () => {
   it("normalizes internal hashes", () => {
@@ -119,5 +132,96 @@ describe("qbittorrentHash", () => {
       selectionFromParsedHashes(parseTorrentHashesFromFormData(file)),
       null
     )
+  })
+
+  describe("compatibilityHashToInternalEd2kHash", () => {
+    it("resolves the reproduced LazyLibrarian base32 mapping", () => {
+      assert.equal(
+        compatibilityHashToInternalEd2kHash(REPRODUCED_BASE32),
+        REPRODUCED_INTERNAL
+      )
+      assert.equal(
+        internalToExternalQbittorrentHash(REPRODUCED_INTERNAL),
+        REPRODUCED_EXTERNAL
+      )
+      assert.equal(
+        compatibilityHashToInternalEd2kHash(REPRODUCED_EXTERNAL),
+        REPRODUCED_INTERNAL
+      )
+    })
+
+    it("accepts uppercase and lowercase base32 with surrounding whitespace", () => {
+      assert.equal(
+        compatibilityHashToInternalEd2kHash(
+          `  ${REPRODUCED_BASE32.toLowerCase()}  `
+        ),
+        REPRODUCED_INTERNAL
+      )
+    })
+
+    it("deduplicates equivalent internal, external and base32 forms", () => {
+      const parsed = parseQbittorrentHashSelection(
+        `${REPRODUCED_INTERNAL}|${REPRODUCED_EXTERNAL}|${REPRODUCED_BASE32}`
+      )
+      assert.equal(parsed.kind, "hashes")
+      if (parsed.kind === "hashes") {
+        assert.deepEqual(parsed.hashes, [REPRODUCED_INTERNAL])
+      }
+    })
+
+    it("matches files when selection uses base32 hashes", () => {
+      const parsed = parseQbittorrentHashSelection(
+        REPRODUCED_BASE32.toLowerCase()
+      )
+      assert.equal(hashSelectionMatchesFile(parsed, REPRODUCED_INTERNAL), true)
+    })
+
+    it("rejects malformed base32 characters", () => {
+      assert.equal(
+        compatibilityHashToInternalEd2kHash("3ZXWM66ZHIOH7FHJZXMKSJFAW4AAAAA0"),
+        null
+      )
+    })
+
+    it("rejects incorrect base32 length", () => {
+      assert.equal(
+        compatibilityHashToInternalEd2kHash("3ZXWM66ZHIOH7FHJZXMKSJFAW4AAAAA"),
+        null
+      )
+      assert.equal(
+        compatibilityHashToInternalEd2kHash(`${REPRODUCED_BASE32}AA`),
+        null
+      )
+    })
+
+    it("rejects arbitrary BitTorrent base32 BTIH with non-zero final four bytes", () => {
+      const arbitrary = Buffer.alloc(20, 0)
+      arbitrary.writeUInt32BE(0x01020304, 16)
+      const encoded = base32.encode(arbitrary)
+      assert.equal(compatibilityHashToInternalEd2kHash(encoded), null)
+    })
+
+    it("rejects invalid 40-character hexadecimal suffix", () => {
+      assert.equal(
+        compatibilityHashToInternalEd2kHash(
+          "de6f667bd93a1c7f94e9cdd8a924a0b7ffffffff"
+        ),
+        null
+      )
+    })
+
+    it("rejects random unsupported values", () => {
+      assert.equal(compatibilityHashToInternalEd2kHash("not-a-hash"), null)
+      assert.equal(compatibilityHashToInternalEd2kHash(""), null)
+    })
+
+    it("accepts synthetic base32 built from internal hashes", () => {
+      const encoded = buildSyntheticBase32FromInternal(SAMPLE)
+      assert.equal(compatibilityHashToInternalEd2kHash(encoded), SAMPLE)
+      assert.equal(
+        compatibilityHashToInternalEd2kHash(encoded.toLowerCase()),
+        SAMPLE
+      )
+    })
   })
 })

--- a/src/app/utils/qbittorrentHash.test.ts
+++ b/src/app/utils/qbittorrentHash.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeInternalEd2kHash,
   parseQbittorrentHashQuery,
   parseQbittorrentHashSelection,
+  parseTorrentHashesFromFormData,
   selectionFromParsedHashes,
 } from "./qbittorrentHash.ts"
 
@@ -15,7 +16,10 @@ const UNKNOWN = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
 
 describe("qbittorrentHash", () => {
   it("normalizes internal hashes", () => {
-    assert.equal(normalizeInternalEd2kHash(`  ${SAMPLE.toLowerCase()}  `), SAMPLE)
+    assert.equal(
+      normalizeInternalEd2kHash(`  ${SAMPLE.toLowerCase()}  `),
+      SAMPLE
+    )
   })
 
   it("converts internal to external hash", () => {
@@ -66,18 +70,9 @@ describe("qbittorrentHash", () => {
   })
 
   it("filters info results by hash selection semantics", () => {
-    assert.equal(
-      hashSelectionMatchesFile({ kind: "absent" }, SAMPLE),
-      true
-    )
-    assert.equal(
-      hashSelectionMatchesFile({ kind: "invalid" }, SAMPLE),
-      false
-    )
-    assert.equal(
-      hashSelectionMatchesFile({ kind: "empty" }, SAMPLE),
-      false
-    )
+    assert.equal(hashSelectionMatchesFile({ kind: "absent" }, SAMPLE), true)
+    assert.equal(hashSelectionMatchesFile({ kind: "invalid" }, SAMPLE), false)
+    assert.equal(hashSelectionMatchesFile({ kind: "empty" }, SAMPLE), false)
     assert.equal(
       hashSelectionMatchesFile({ kind: "hashes", hashes: [SAMPLE] }, SAMPLE),
       true
@@ -85,6 +80,44 @@ describe("qbittorrentHash", () => {
     assert.equal(
       hashSelectionMatchesFile({ kind: "hashes", hashes: [UNKNOWN] }, SAMPLE),
       false
+    )
+  })
+
+  it("parses torrent hashes from multipart form data", () => {
+    const absent = new FormData()
+    assert.deepEqual(parseTorrentHashesFromFormData(absent), { kind: "absent" })
+
+    const empty = new FormData()
+    empty.set("hashes", "")
+    assert.deepEqual(parseTorrentHashesFromFormData(empty), { kind: "empty" })
+
+    const valid = new FormData()
+    valid.set("hashes", `${SAMPLE.toLowerCase()}00000000`)
+    const parsedValid = parseTorrentHashesFromFormData(valid)
+    assert.equal(parsedValid.kind, "hashes")
+    if (parsedValid.kind === "hashes") {
+      assert.deepEqual(parsedValid.hashes, [SAMPLE])
+    }
+
+    const all = new FormData()
+    all.set("hashes", "all")
+    assert.deepEqual(parseTorrentHashesFromFormData(all), { kind: "all" })
+
+    const malformed = new FormData()
+    malformed.set("hashes", "not-a-hash")
+    assert.deepEqual(parseTorrentHashesFromFormData(malformed), {
+      kind: "invalid",
+    })
+
+    const file = new FormData()
+    file.set(
+      "hashes",
+      new File(["ignored"], "hashes.txt", { type: "text/plain" })
+    )
+    assert.deepEqual(parseTorrentHashesFromFormData(file), { kind: "invalid" })
+    assert.equal(
+      selectionFromParsedHashes(parseTorrentHashesFromFormData(file)),
+      null
     )
   })
 })

--- a/src/app/utils/qbittorrentHash.test.ts
+++ b/src/app/utils/qbittorrentHash.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import {
+  externalToInternalEd2kHash,
+  internalToExternalQbittorrentHash,
+  normalizeInternalEd2kHash,
+  parseQbittorrentHashSelection,
+} from "./qbittorrentHash.ts"
+
+const SAMPLE = "A1B2C3D4E5F6789012345678ABCDEF01"
+
+describe("qbittorrentHash", () => {
+  it("normalizes internal hashes", () => {
+    assert.equal(normalizeInternalEd2kHash(`  ${SAMPLE.toLowerCase()}  `), SAMPLE)
+  })
+
+  it("converts internal to external hash", () => {
+    assert.equal(
+      internalToExternalQbittorrentHash(SAMPLE),
+      `${SAMPLE.toLowerCase()}00000000`
+    )
+  })
+
+  it("converts external compatibility hash to internal", () => {
+    assert.equal(
+      externalToInternalEd2kHash(`${SAMPLE.toLowerCase()}00000000`),
+      SAMPLE
+    )
+  })
+
+  it("rejects arbitrary 40-character hashes", () => {
+    assert.equal(
+      externalToInternalEd2kHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+      null
+    )
+  })
+
+  it("parses hashes=all", () => {
+    assert.deepEqual(parseQbittorrentHashSelection("ALL"), { kind: "all" })
+  })
+
+  it("parses pipe-separated mixed-case hashes", () => {
+    const parsed = parseQbittorrentHashSelection(
+      `${SAMPLE}|${SAMPLE.toLowerCase()}00000000`
+    )
+    assert.equal(parsed.kind, "hashes")
+    if (parsed.kind === "hashes") {
+      assert.deepEqual(parsed.hashes, [SAMPLE])
+    }
+  })
+
+  it("rejects malformed selections", () => {
+    assert.deepEqual(parseQbittorrentHashSelection("not-a-hash"), { kind: "none" })
+  })
+})

--- a/src/app/utils/qbittorrentHash.ts
+++ b/src/app/utils/qbittorrentHash.ts
@@ -6,9 +6,11 @@ const INTERNAL_HASH_RE = /^[0-9A-F]{32}$/
 const EXTERNAL_HASH_RE = /^[0-9A-F]{40}$/
 
 export type ParsedQbittorrentHashSelection =
-  | { kind: "none" }
+  | { kind: "absent" }
+  | { kind: "empty" }
   | { kind: "all" }
   | { kind: "hashes"; hashes: string[] }
+  | { kind: "invalid" }
 
 export function normalizeInternalEd2kHash(value: string): string | null {
   const hash = value.trim().toUpperCase()
@@ -43,13 +45,13 @@ export function externalToInternalEd2kHash(value: string): string | null {
 export function parseQbittorrentHashSelection(
   value: string | null | undefined
 ): ParsedQbittorrentHashSelection {
-  if (typeof value !== "string") {
-    return { kind: "none" }
+  if (value === null || value === undefined) {
+    return { kind: "empty" }
   }
 
   const raw = value.trim()
   if (!raw) {
-    return { kind: "none" }
+    return { kind: "empty" }
   }
 
   if (raw.toLowerCase() === "all") {
@@ -68,14 +70,61 @@ export function parseQbittorrentHashSelection(
   ]
 
   if (!hashes.length) {
-    return { kind: "none" }
+    return { kind: "invalid" }
   }
 
   return { kind: "hashes", hashes }
 }
 
+export function parseQbittorrentHashQuery(
+  hashesParamPresent: boolean,
+  value: string | null
+): ParsedQbittorrentHashSelection {
+  if (!hashesParamPresent) {
+    return { kind: "absent" }
+  }
+
+  return parseQbittorrentHashSelection(value)
+}
+
 export function parseTorrentHashesFromFormData(
   formData: FormData
 ): ParsedQbittorrentHashSelection {
+  if (!formData.has("hashes")) {
+    return { kind: "absent" }
+  }
+
   return parseQbittorrentHashSelection(formData.get("hashes")?.toString())
+}
+
+export function selectionFromParsedHashes(
+  parsed: ParsedQbittorrentHashSelection
+): "all" | string[] | null {
+  if (parsed.kind === "all") {
+    return "all"
+  }
+
+  if (parsed.kind === "hashes") {
+    return parsed.hashes
+  }
+
+  return null
+}
+
+export function hashSelectionMatchesFile(
+  selection: ParsedQbittorrentHashSelection,
+  fileHash: string
+): boolean {
+  switch (selection.kind) {
+    case "absent":
+    case "all":
+      return true
+    case "empty":
+    case "invalid":
+      return false
+    case "hashes": {
+      const wanted = new Set(selection.hashes.map((hash) => hash.toUpperCase()))
+      return wanted.has(fileHash.toUpperCase())
+    }
+  }
 }

--- a/src/app/utils/qbittorrentHash.ts
+++ b/src/app/utils/qbittorrentHash.ts
@@ -94,7 +94,12 @@ export function parseTorrentHashesFromFormData(
     return { kind: "absent" }
   }
 
-  return parseQbittorrentHashSelection(formData.get("hashes")?.toString())
+  const value = formData.get("hashes")
+  if (typeof value !== "string") {
+    return { kind: "invalid" }
+  }
+
+  return parseQbittorrentHashSelection(value)
 }
 
 export function selectionFromParsedHashes(

--- a/src/app/utils/qbittorrentHash.ts
+++ b/src/app/utils/qbittorrentHash.ts
@@ -1,0 +1,81 @@
+export const INTERNAL_ED2K_HASH_LENGTH = 32
+export const EXTERNAL_QBITTORRENT_HASH_LENGTH = 40
+export const EXTERNAL_HASH_PADDING = "00000000"
+
+const INTERNAL_HASH_RE = /^[0-9A-F]{32}$/
+const EXTERNAL_HASH_RE = /^[0-9A-F]{40}$/
+
+export type ParsedQbittorrentHashSelection =
+  | { kind: "none" }
+  | { kind: "all" }
+  | { kind: "hashes"; hashes: string[] }
+
+export function normalizeInternalEd2kHash(value: string): string | null {
+  const hash = value.trim().toUpperCase()
+  return INTERNAL_HASH_RE.test(hash) ? hash : null
+}
+
+export function internalToExternalQbittorrentHash(
+  value: string
+): string | null {
+  const internal = normalizeInternalEd2kHash(value)
+  if (!internal) {
+    return null
+  }
+
+  return `${internal}${EXTERNAL_HASH_PADDING}`.toLowerCase()
+}
+
+export function externalToInternalEd2kHash(value: string): string | null {
+  const hash = value.trim().toUpperCase()
+
+  if (INTERNAL_HASH_RE.test(hash)) {
+    return hash
+  }
+
+  if (EXTERNAL_HASH_RE.test(hash) && hash.endsWith(EXTERNAL_HASH_PADDING)) {
+    return hash.slice(0, INTERNAL_ED2K_HASH_LENGTH)
+  }
+
+  return null
+}
+
+export function parseQbittorrentHashSelection(
+  value: string | null | undefined
+): ParsedQbittorrentHashSelection {
+  if (typeof value !== "string") {
+    return { kind: "none" }
+  }
+
+  const raw = value.trim()
+  if (!raw) {
+    return { kind: "none" }
+  }
+
+  if (raw.toLowerCase() === "all") {
+    return { kind: "all" }
+  }
+
+  const hashes = [
+    ...new Set(
+      raw
+        .split("|")
+        .map((part) => part.trim())
+        .filter(Boolean)
+        .map(externalToInternalEd2kHash)
+        .filter((hash): hash is string => hash !== null)
+    ),
+  ]
+
+  if (!hashes.length) {
+    return { kind: "none" }
+  }
+
+  return { kind: "hashes", hashes }
+}
+
+export function parseTorrentHashesFromFormData(
+  formData: FormData
+): ParsedQbittorrentHashSelection {
+  return parseQbittorrentHashSelection(formData.get("hashes")?.toString())
+}

--- a/src/app/utils/qbittorrentHash.ts
+++ b/src/app/utils/qbittorrentHash.ts
@@ -1,9 +1,12 @@
+import base32 from "hi-base32"
+
 export const INTERNAL_ED2K_HASH_LENGTH = 32
 export const EXTERNAL_QBITTORRENT_HASH_LENGTH = 40
 export const EXTERNAL_HASH_PADDING = "00000000"
 
 const INTERNAL_HASH_RE = /^[0-9A-F]{32}$/
 const EXTERNAL_HASH_RE = /^[0-9A-F]{40}$/
+const SYNTHETIC_BASE32_BTih_RE = /^[A-Z2-7]{32}$/
 
 export type ParsedQbittorrentHashSelection =
   | { kind: "absent" }
@@ -28,18 +31,56 @@ export function internalToExternalQbittorrentHash(
   return `${internal}${EXTERNAL_HASH_PADDING}`.toLowerCase()
 }
 
+function decodeSyntheticBase32BtihToInternal(value: string): string | null {
+  const normalized = value.trim().toUpperCase()
+  if (!SYNTHETIC_BASE32_BTih_RE.test(normalized)) {
+    return null
+  }
+
+  try {
+    const bytes = Buffer.from(base32.decode.asBytes(normalized))
+    if (bytes.length !== 20) {
+      return null
+    }
+
+    if (!bytes.subarray(16).every((byte) => byte === 0)) {
+      return null
+    }
+
+    return normalizeInternalEd2kHash(bytes.subarray(0, 16).toString("hex"))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Resolve a qBittorrent-compatible hash to the canonical internal eD2K hash.
+ *
+ * Accepted forms:
+ * - 32-character internal eD2K hex (case-insensitive, surrounding whitespace trimmed)
+ * - 40-character external hex ending in 00000000
+ * - 32-character synthetic base32 BTIH (A-Z2-7, case-insensitive) whose decoded
+ *   trailing four bytes are zero (eMulerr synthetic magnets only)
+ */
+export function compatibilityHashToInternalEd2kHash(
+  value: string
+): string | null {
+  const trimmed = value.trim()
+  const upper = trimmed.toUpperCase()
+
+  if (INTERNAL_HASH_RE.test(upper)) {
+    return upper
+  }
+
+  if (EXTERNAL_HASH_RE.test(upper) && upper.endsWith(EXTERNAL_HASH_PADDING)) {
+    return upper.slice(0, INTERNAL_ED2K_HASH_LENGTH)
+  }
+
+  return decodeSyntheticBase32BtihToInternal(trimmed)
+}
+
 export function externalToInternalEd2kHash(value: string): string | null {
-  const hash = value.trim().toUpperCase()
-
-  if (INTERNAL_HASH_RE.test(hash)) {
-    return hash
-  }
-
-  if (EXTERNAL_HASH_RE.test(hash) && hash.endsWith(EXTERNAL_HASH_PADDING)) {
-    return hash.slice(0, INTERNAL_ED2K_HASH_LENGTH)
-  }
-
-  return null
+  return compatibilityHashToInternalEd2kHash(value)
 }
 
 export function parseQbittorrentHashSelection(
@@ -64,7 +105,7 @@ export function parseQbittorrentHashSelection(
         .split("|")
         .map((part) => part.trim())
         .filter(Boolean)
-        .map(externalToInternalEd2kHash)
+        .map(compatibilityHashToInternalEd2kHash)
         .filter((hash): hash is string => hash !== null)
     ),
   ]

--- a/src/app/utils/qbittorrentMagnet.test.ts
+++ b/src/app/utils/qbittorrentMagnet.test.ts
@@ -7,63 +7,41 @@ import {
 } from "./qbittorrentMagnet.ts"
 
 const HASH = "A1B2C3D4E5F6789012345678ABCDEF01"
-const NAME = "Example Book.epub"
 const SIZE = 12345
 
-function buildMagnet(hash: string, name: string, size: number) {
-  const hashBuffer = Buffer.from(hash, "hex")
+function buildMagnet(name: string) {
+  const hashBuffer = Buffer.from(HASH, "hex")
   const base32Buffer = Buffer.alloc(20, "\0")
   hashBuffer.copy(base32Buffer)
   const base32Hash = base32.encode(base32Buffer).toUpperCase()
-  return `magnet:?xt=urn:btih:${base32Hash}&dn=${encodeURIComponent(name)}&xl=${size}&tr=http://emulerr`
+  return `magnet:?xt=urn:btih:${base32Hash}&dn=${encodeURIComponent(name)}&xl=${SIZE}&tr=http://emulerr`
 }
 
 describe("qbittorrentMagnet", () => {
-  it("parses synthetic eMulerr magnets", () => {
-    const magnet = buildMagnet(HASH, NAME, SIZE)
-    assert.deepEqual(parseSyntheticMagnetLink(magnet), {
+  it("returns dn without double decoding", () => {
+    const name = "100% complete & café + test"
+    assert.deepEqual(parseSyntheticMagnetLink(buildMagnet(name)), {
       hash: HASH,
-      name: NAME,
+      name,
       size: SIZE,
     })
   })
 
   it("accepts reordered magnet parameters", () => {
-    const magnet = buildMagnet(HASH, NAME, SIZE)
+    const magnet = buildMagnet("Example.epub")
     const [, query = ""] = magnet.split("magnet:?")
     const params = new URLSearchParams(query)
     const reordered = `magnet:?dn=${params.get("dn")}&tr=http://emulerr&xl=${SIZE}&xt=${params.get("xt")}`
-    assert.deepEqual(parseSyntheticMagnetLink(reordered), {
-      hash: HASH,
-      name: NAME,
-      size: SIZE,
-    })
+    assert.equal(parseSyntheticMagnetLink(reordered).name, "Example.epub")
   })
 
   it("accepts hexadecimal compatibility hashes", () => {
-    const magnet = `magnet:?xt=urn:btih:${HASH.toLowerCase()}00000000&dn=${encodeURIComponent(NAME)}&xl=${SIZE}`
-    assert.deepEqual(parseSyntheticMagnetLink(magnet), {
-      hash: HASH,
-      name: NAME,
-      size: SIZE,
-    })
+    const magnet = `magnet:?xt=urn:btih:${HASH.toLowerCase()}00000000&dn=${encodeURIComponent("Example.epub")}&xl=${SIZE}`
+    assert.equal(parseSyntheticMagnetLink(magnet).hash, HASH)
   })
 
   it("rejects non-emulerr btih values", () => {
-    const magnet = `magnet:?xt=urn:btih:${"a".repeat(40)}&dn=${encodeURIComponent(NAME)}&xl=${SIZE}`
-    assert.throws(
-      () => parseSyntheticMagnetLink(magnet),
-      MagnetParseError
-    )
-  })
-
-  it("rejects missing dn and invalid xl", () => {
-    assert.throws(
-      () =>
-        parseSyntheticMagnetLink(
-          `magnet:?xt=urn:btih:${HASH.toLowerCase()}00000000&xl=0`
-        ),
-      MagnetParseError
-    )
+    const magnet = `magnet:?xt=urn:btih:${"a".repeat(40)}&dn=${encodeURIComponent("Example.epub")}&xl=${SIZE}`
+    assert.throws(() => parseSyntheticMagnetLink(magnet), MagnetParseError)
   })
 })

--- a/src/app/utils/qbittorrentMagnet.test.ts
+++ b/src/app/utils/qbittorrentMagnet.test.ts
@@ -40,6 +40,15 @@ describe("qbittorrentMagnet", () => {
     assert.equal(parseSyntheticMagnetLink(magnet).hash, HASH)
   })
 
+  it("accepts the reproduced LazyLibrarian base32 BTIH", () => {
+    const magnet =
+      "magnet:?xt=urn:btih:3ZXWM66ZHIOH7FHJZXMKSJFAW4AAAAAA&dn=Hackable%20Magazine&xl=105047352&tr=http://emulerr"
+    assert.equal(
+      parseSyntheticMagnetLink(magnet).hash,
+      "DE6F667BD93A1C7F94E9CDD8A924A0B7"
+    )
+  })
+
   it("rejects non-emulerr btih values", () => {
     const magnet = `magnet:?xt=urn:btih:${"a".repeat(40)}&dn=${encodeURIComponent("Example.epub")}&xl=${SIZE}`
     assert.throws(() => parseSyntheticMagnetLink(magnet), MagnetParseError)

--- a/src/app/utils/qbittorrentMagnet.test.ts
+++ b/src/app/utils/qbittorrentMagnet.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import base32 from "hi-base32"
+import {
+  MagnetParseError,
+  parseSyntheticMagnetLink,
+} from "./qbittorrentMagnet.ts"
+
+const HASH = "A1B2C3D4E5F6789012345678ABCDEF01"
+const NAME = "Example Book.epub"
+const SIZE = 12345
+
+function buildMagnet(hash: string, name: string, size: number) {
+  const hashBuffer = Buffer.from(hash, "hex")
+  const base32Buffer = Buffer.alloc(20, "\0")
+  hashBuffer.copy(base32Buffer)
+  const base32Hash = base32.encode(base32Buffer).toUpperCase()
+  return `magnet:?xt=urn:btih:${base32Hash}&dn=${encodeURIComponent(name)}&xl=${size}&tr=http://emulerr`
+}
+
+describe("qbittorrentMagnet", () => {
+  it("parses synthetic eMulerr magnets", () => {
+    const magnet = buildMagnet(HASH, NAME, SIZE)
+    assert.deepEqual(parseSyntheticMagnetLink(magnet), {
+      hash: HASH,
+      name: NAME,
+      size: SIZE,
+    })
+  })
+
+  it("accepts reordered magnet parameters", () => {
+    const magnet = buildMagnet(HASH, NAME, SIZE)
+    const [, query = ""] = magnet.split("magnet:?")
+    const params = new URLSearchParams(query)
+    const reordered = `magnet:?dn=${params.get("dn")}&tr=http://emulerr&xl=${SIZE}&xt=${params.get("xt")}`
+    assert.deepEqual(parseSyntheticMagnetLink(reordered), {
+      hash: HASH,
+      name: NAME,
+      size: SIZE,
+    })
+  })
+
+  it("accepts hexadecimal compatibility hashes", () => {
+    const magnet = `magnet:?xt=urn:btih:${HASH.toLowerCase()}00000000&dn=${encodeURIComponent(NAME)}&xl=${SIZE}`
+    assert.deepEqual(parseSyntheticMagnetLink(magnet), {
+      hash: HASH,
+      name: NAME,
+      size: SIZE,
+    })
+  })
+
+  it("rejects non-emulerr btih values", () => {
+    const magnet = `magnet:?xt=urn:btih:${"a".repeat(40)}&dn=${encodeURIComponent(NAME)}&xl=${SIZE}`
+    assert.throws(
+      () => parseSyntheticMagnetLink(magnet),
+      MagnetParseError
+    )
+  })
+
+  it("rejects missing dn and invalid xl", () => {
+    assert.throws(
+      () =>
+        parseSyntheticMagnetLink(
+          `magnet:?xt=urn:btih:${HASH.toLowerCase()}00000000&xl=0`
+        ),
+      MagnetParseError
+    )
+  })
+})

--- a/src/app/utils/qbittorrentMagnet.ts
+++ b/src/app/utils/qbittorrentMagnet.ts
@@ -89,7 +89,7 @@ export function parseSyntheticMagnetLink(magnetLink: string): {
 
   return {
     hash,
-    name: decodeURIComponent(dn),
+    name: dn,
     size,
   }
 }

--- a/src/app/utils/qbittorrentMagnet.ts
+++ b/src/app/utils/qbittorrentMagnet.ts
@@ -1,0 +1,95 @@
+import base32 from "hi-base32"
+import {
+  EXTERNAL_HASH_PADDING,
+  normalizeInternalEd2kHash,
+} from "~/utils/qbittorrentHash"
+
+export class MagnetParseError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "MagnetParseError"
+  }
+}
+
+function decodeBtihToInternalHash(btih: string): string {
+  const value = btih.trim()
+
+  if (/^[0-9A-Fa-f]{40}$/.test(value)) {
+    const upper = value.toUpperCase()
+    if (!upper.endsWith(EXTERNAL_HASH_PADDING)) {
+      throw new MagnetParseError("Unsupported BitTorrent info hash")
+    }
+
+    const internal = normalizeInternalEd2kHash(upper.slice(0, 32))
+    if (!internal) {
+      throw new MagnetParseError("Invalid compatibility info hash")
+    }
+
+    return internal
+  }
+
+  try {
+    const bytes = Buffer.from(base32.decode.asBytes(value.toUpperCase()))
+    if (bytes.length !== 20) {
+      throw new MagnetParseError("Invalid base32 info hash length")
+    }
+
+    if (!bytes.subarray(16).every((byte) => byte === 0)) {
+      throw new MagnetParseError("Unsupported BitTorrent info hash")
+    }
+
+    const internal = normalizeInternalEd2kHash(
+      bytes.subarray(0, 16).toString("hex")
+    )
+    if (!internal) {
+      throw new MagnetParseError("Invalid eD2K info hash")
+    }
+
+    return internal
+  } catch (error) {
+    if (error instanceof MagnetParseError) {
+      throw error
+    }
+
+    throw new MagnetParseError("Invalid magnet info hash")
+  }
+}
+
+export function parseSyntheticMagnetLink(magnetLink: string): {
+  hash: string
+  name: string
+  size: number
+} {
+  const trimmed = magnetLink.trim()
+  if (!trimmed.toLowerCase().startsWith("magnet:?")) {
+    throw new MagnetParseError("Invalid magnet protocol")
+  }
+
+  const params = new URLSearchParams(trimmed.slice("magnet:?".length))
+  const xt = params.get("xt")
+  if (!xt?.toLowerCase().startsWith("urn:btih:")) {
+    throw new MagnetParseError("Missing or invalid xt parameter")
+  }
+
+  const hash = decodeBtihToInternalHash(xt.slice("urn:btih:".length))
+  const dn = params.get("dn")?.trim()
+  if (!dn) {
+    throw new MagnetParseError("Missing dn parameter")
+  }
+
+  const xl = params.get("xl")?.trim()
+  if (!xl || !/^\d+$/.test(xl)) {
+    throw new MagnetParseError("Invalid xl parameter")
+  }
+
+  const size = Number.parseInt(xl, 10)
+  if (!Number.isSafeInteger(size) || size <= 0) {
+    throw new MagnetParseError("Invalid xl parameter")
+  }
+
+  return {
+    hash,
+    name: decodeURIComponent(dn),
+    size,
+  }
+}

--- a/src/app/utils/qbittorrentMagnet.ts
+++ b/src/app/utils/qbittorrentMagnet.ts
@@ -1,8 +1,4 @@
-import base32 from "hi-base32"
-import {
-  EXTERNAL_HASH_PADDING,
-  normalizeInternalEd2kHash,
-} from "~/utils/qbittorrentHash"
+import { compatibilityHashToInternalEd2kHash } from "~/utils/qbittorrentHash"
 
 export class MagnetParseError extends Error {
   constructor(message: string) {
@@ -12,47 +8,17 @@ export class MagnetParseError extends Error {
 }
 
 function decodeBtihToInternalHash(btih: string): string {
+  const internal = compatibilityHashToInternalEd2kHash(btih)
+  if (internal) {
+    return internal
+  }
+
   const value = btih.trim()
-
   if (/^[0-9A-Fa-f]{40}$/.test(value)) {
-    const upper = value.toUpperCase()
-    if (!upper.endsWith(EXTERNAL_HASH_PADDING)) {
-      throw new MagnetParseError("Unsupported BitTorrent info hash")
-    }
-
-    const internal = normalizeInternalEd2kHash(upper.slice(0, 32))
-    if (!internal) {
-      throw new MagnetParseError("Invalid compatibility info hash")
-    }
-
-    return internal
+    throw new MagnetParseError("Unsupported BitTorrent info hash")
   }
 
-  try {
-    const bytes = Buffer.from(base32.decode.asBytes(value.toUpperCase()))
-    if (bytes.length !== 20) {
-      throw new MagnetParseError("Invalid base32 info hash length")
-    }
-
-    if (!bytes.subarray(16).every((byte) => byte === 0)) {
-      throw new MagnetParseError("Unsupported BitTorrent info hash")
-    }
-
-    const internal = normalizeInternalEd2kHash(
-      bytes.subarray(0, 16).toString("hex")
-    )
-    if (!internal) {
-      throw new MagnetParseError("Invalid eD2K info hash")
-    }
-
-    return internal
-  } catch (error) {
-    if (error instanceof MagnetParseError) {
-      throw error
-    }
-
-    throw new MagnetParseError("Invalid magnet info hash")
-  }
+  throw new MagnetParseError("Invalid magnet info hash")
 }
 
 export function parseSyntheticMagnetLink(magnetLink: string): {

--- a/src/app/utils/qbittorrentPathSafety.test.ts
+++ b/src/app/utils/qbittorrentPathSafety.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import {
+  isSafeFileName,
+  resolveSafeFilePath,
+} from "./qbittorrentPathSafety.ts"
+
+describe("qbittorrentPathSafety", () => {
+  it("rejects traversal attempts", () => {
+    assert.equal(isSafeFileName("../secret.txt"), false)
+    assert.equal(resolveSafeFilePath("/downloads/complete", "../secret.txt"), null)
+  })
+
+  it("resolves contained paths", () => {
+    assert.equal(
+      resolveSafeFilePath("/downloads/complete", "book.epub"),
+      "/downloads/complete/book.epub"
+    )
+  })
+})

--- a/src/app/utils/qbittorrentPathSafety.ts
+++ b/src/app/utils/qbittorrentPathSafety.ts
@@ -1,0 +1,42 @@
+import { posix } from "node:path"
+
+export const COMPLETE_DOWNLOAD_ROOT = "/downloads/complete"
+export const INCOMPLETE_DOWNLOAD_ROOT = "/downloads/incomplete"
+export const SHARED_DOWNLOAD_ROOT = "/tmp/shared"
+
+const ALLOWED_ROOTS = [
+  COMPLETE_DOWNLOAD_ROOT,
+  INCOMPLETE_DOWNLOAD_ROOT,
+  SHARED_DOWNLOAD_ROOT,
+]
+
+export function isSafeFileName(fileName: string): boolean {
+  return (
+    fileName.length > 0 &&
+    !fileName.includes("/") &&
+    !fileName.includes("\\") &&
+    !fileName.includes("..")
+  )
+}
+
+export function resolveSafeFilePath(
+  root: string,
+  fileName: string
+): string | null {
+  if (!ALLOWED_ROOTS.includes(root) || !isSafeFileName(fileName)) {
+    return null
+  }
+
+  const normalizedRoot = posix.resolve(root)
+  const candidate = posix.resolve(normalizedRoot, fileName)
+
+  if (candidate === normalizedRoot) {
+    return null
+  }
+
+  if (!candidate.startsWith(`${normalizedRoot}/`)) {
+    return null
+  }
+
+  return candidate
+}

--- a/src/app/utils/qbittorrentTimestamps.test.ts
+++ b/src/app/utils/qbittorrentTimestamps.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict"
 import { describe, it } from "node:test"
-import { timestampToUnixSeconds } from "./qbittorrentTimestamps.ts"
+import {
+  timestampToUnixSeconds,
+  torrentTimestampsFromMetadata,
+} from "./qbittorrentTimestamps.ts"
 
 describe("qbittorrentTimestamps", () => {
   it("converts milliseconds to seconds", () => {
@@ -9,5 +12,27 @@ describe("qbittorrentTimestamps", () => {
 
   it("preserves values already in seconds", () => {
     assert.equal(timestampToUnixSeconds(1_700_000_000), 1_700_000_000)
+  })
+
+  it("returns zero for missing timestamps", () => {
+    assert.equal(timestampToUnixSeconds(undefined), 0)
+    assert.deepEqual(torrentTimestampsFromMetadata(undefined), {
+      added_on: 0,
+      completion_on: 0,
+      addition_date: 0,
+      completion_date: 0,
+    })
+  })
+
+  it("keeps info and properties timestamps consistent", () => {
+    const meta = {
+      addedOn: 1_700_000_000_000,
+      completionOn: 1_700_000_100_000,
+    }
+    const timestamps = torrentTimestampsFromMetadata(meta)
+    assert.equal(timestamps.added_on, timestamps.addition_date)
+    assert.equal(timestamps.completion_on, timestamps.completion_date)
+    assert.equal(timestamps.added_on, 1_700_000_000)
+    assert.equal(timestamps.completion_on, 1_700_000_100)
   })
 })

--- a/src/app/utils/qbittorrentTimestamps.test.ts
+++ b/src/app/utils/qbittorrentTimestamps.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { timestampToUnixSeconds } from "./qbittorrentTimestamps.ts"
+
+describe("qbittorrentTimestamps", () => {
+  it("converts milliseconds to seconds", () => {
+    assert.equal(timestampToUnixSeconds(1_700_000_000_000), 1_700_000_000)
+  })
+
+  it("preserves values already in seconds", () => {
+    assert.equal(timestampToUnixSeconds(1_700_000_000), 1_700_000_000)
+  })
+})

--- a/src/app/utils/qbittorrentTimestamps.ts
+++ b/src/app/utils/qbittorrentTimestamps.ts
@@ -2,7 +2,7 @@ const MS_THRESHOLD = 1_000_000_000_000
 
 export function timestampToUnixSeconds(value: number | undefined): number {
   if (value === undefined) {
-    return Math.floor(Date.now() / 1000)
+    return 0
   }
 
   if (value >= MS_THRESHOLD) {
@@ -10,4 +10,16 @@ export function timestampToUnixSeconds(value: number | undefined): number {
   }
 
   return value
+}
+
+export function torrentTimestampsFromMetadata(meta?: {
+  addedOn?: number
+  completionOn?: number
+}) {
+  return {
+    added_on: timestampToUnixSeconds(meta?.addedOn),
+    completion_on: timestampToUnixSeconds(meta?.completionOn),
+    addition_date: timestampToUnixSeconds(meta?.addedOn),
+    completion_date: timestampToUnixSeconds(meta?.completionOn),
+  }
 }

--- a/src/app/utils/qbittorrentTimestamps.ts
+++ b/src/app/utils/qbittorrentTimestamps.ts
@@ -1,0 +1,13 @@
+const MS_THRESHOLD = 1_000_000_000_000
+
+export function timestampToUnixSeconds(value: number | undefined): number {
+  if (value === undefined) {
+    return Math.floor(Date.now() / 1000)
+  }
+
+  if (value >= MS_THRESHOLD) {
+    return Math.floor(value / 1000)
+  }
+
+  return value
+}

--- a/src/app/utils/qbittorrentTorrentAdd.test.ts
+++ b/src/app/utils/qbittorrentTorrentAdd.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { parseTorrentAddOptions } from "./qbittorrentTorrentAdd.ts"
+
+describe("qbittorrentTorrentAdd", () => {
+  it("defaults paused to false when paused and stopped are absent", () => {
+    const formData = new FormData()
+    formData.set(
+      "urls",
+      "magnet:?xt=urn:btih:A1B2C3D4E5F6789012345678ABCDEF0100000000&dn=test&xl=1"
+    )
+
+    assert.deepEqual(parseTorrentAddOptions(formData), {
+      category: "",
+      paused: false,
+    })
+  })
+
+  it("defaults category to empty string when absent", () => {
+    const formData = new FormData()
+    formData.set("urls", "magnet:?xt=urn:btih:test&dn=test&xl=1")
+    formData.set("paused", "false")
+
+    assert.equal(parseTorrentAddOptions(formData).category, "")
+    assert.equal(parseTorrentAddOptions(formData).paused, false)
+  })
+
+  it("accepts paused=true and stopped=true", () => {
+    const pausedForm = new FormData()
+    pausedForm.set("paused", "true")
+    assert.equal(parseTorrentAddOptions(pausedForm).paused, true)
+
+    const stoppedForm = new FormData()
+    stoppedForm.set("stopped", "true")
+    assert.equal(parseTorrentAddOptions(stoppedForm).paused, true)
+  })
+})

--- a/src/app/utils/qbittorrentTorrentAdd.ts
+++ b/src/app/utils/qbittorrentTorrentAdd.ts
@@ -1,0 +1,8 @@
+export function parseTorrentAddOptions(formData: FormData) {
+  const category = formData.get("category")?.toString() ?? ""
+  const paused =
+    formData.get("paused")?.toString().trim().toLowerCase() === "true" ||
+    formData.get("stopped")?.toString().trim().toLowerCase() === "true"
+
+  return { category, paused }
+}

--- a/src/app/utils/qbittorrentTorrentResponse.test.ts
+++ b/src/app/utils/qbittorrentTorrentResponse.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import {
+  buildQbittorrentTorrentInfo,
+  buildQbittorrentTorrentProperties,
+} from "./qbittorrentTorrentResponse.ts"
+import {
+  COMPLETE_DOWNLOAD_ROOT,
+  resolveSafeFilePath,
+} from "./qbittorrentPathSafety.ts"
+
+const file = {
+  hash: "A1B2C3D4E5F6789012345678ABCDEF01",
+  name: "Example.epub",
+  size: 1000,
+  size_done: 1000,
+  progress: 1,
+  speed: 0,
+  up_speed: 0,
+  eta: 0,
+  status_str: "downloaded" as const,
+  meta: {
+    category: "books",
+    addedOn: 1_700_000_000_000,
+    completionOn: 1_700_000_100_000,
+  },
+}
+
+describe("qbittorrentTorrentResponse", () => {
+  it("builds stable unix-second timestamps", () => {
+    const info = buildQbittorrentTorrentInfo(file)
+    const properties = buildQbittorrentTorrentProperties(file)
+    assert.equal(info?.added_on, 1_700_000_000)
+    assert.equal(info?.completion_on, 1_700_000_100)
+    assert.equal(properties.addition_date, info?.added_on)
+    assert.equal(properties.completion_date, info?.completion_on)
+  })
+
+  it("uses safe content paths", () => {
+    assert.equal(
+      resolveSafeFilePath(COMPLETE_DOWNLOAD_ROOT, file.name),
+      `${COMPLETE_DOWNLOAD_ROOT}/${file.name}`
+    )
+    assert.equal(resolveSafeFilePath(COMPLETE_DOWNLOAD_ROOT, "../x"), null)
+  })
+})

--- a/src/app/utils/qbittorrentTorrentResponse.test.ts
+++ b/src/app/utils/qbittorrentTorrentResponse.test.ts
@@ -3,6 +3,8 @@ import { describe, it } from "node:test"
 import {
   buildQbittorrentTorrentInfo,
   buildQbittorrentTorrentProperties,
+  COMPLETED_SEEDING_TIME_SECONDS,
+  QBITTORRENT_APP_PREFERENCES,
 } from "./qbittorrentTorrentResponse.ts"
 import {
   COMPLETE_DOWNLOAD_ROOT,
@@ -42,5 +44,14 @@ describe("qbittorrentTorrentResponse", () => {
       `${COMPLETE_DOWNLOAD_ROOT}/${file.name}`
     )
     assert.equal(resolveSafeFilePath(COMPLETE_DOWNLOAD_ROOT, "../x"), null)
+  })
+
+  it("exposes completed seeding time for LazyLibrarian compatibility", () => {
+    const info = buildQbittorrentTorrentInfo(file)
+    assert.equal(info?.seeding_time, COMPLETED_SEEDING_TIME_SECONDS)
+    assert.equal(
+      QBITTORRENT_APP_PREFERENCES.max_seeding_time,
+      COMPLETED_SEEDING_TIME_SECONDS
+    )
   })
 })

--- a/src/app/utils/qbittorrentTorrentResponse.ts
+++ b/src/app/utils/qbittorrentTorrentResponse.ts
@@ -2,11 +2,13 @@ import { existsSync } from "node:fs"
 import { amuleGetDownloads } from "amule/amule"
 import {
   COMPLETE_DOWNLOAD_ROOT,
+  INCOMPLETE_DOWNLOAD_ROOT,
+  resolveSafeFilePath,
   SHARED_DOWNLOAD_ROOT,
 } from "~/utils/qbittorrentPathSafety"
 import { internalToExternalQbittorrentHash } from "~/utils/qbittorrentHash"
-import { timestampToUnixSeconds } from "~/utils/qbittorrentTimestamps"
-import type { DownloadClientFile, HashMetadata } from "~/data/downloadClient"
+import { torrentTimestampsFromMetadata } from "~/utils/qbittorrentTimestamps"
+import type { DownloadClientFile } from "~/data/downloadClient"
 
 export const QBITTORRENT_SAVE_PATH = COMPLETE_DOWNLOAD_ROOT
 
@@ -14,6 +16,7 @@ export const QBITTORRENT_SAVE_PATH = COMPLETE_DOWNLOAD_ROOT
 // aMule has no BitTorrent ratio; completed eD2K items always expose ratio 1.0.
 export const COMPLETED_COMPAT_RATIO = 1.0
 export const INCOMPLETE_COMPAT_RATIO = 0.0
+export const COMPLETED_SEEDING_TIME_SECONDS = 86400
 
 export function statusToQbittorrentState(
   status: Awaited<ReturnType<typeof amuleGetDownloads>>[0]["status_str"]
@@ -34,13 +37,16 @@ export function statusToQbittorrentState(
   }
 }
 
-function contentPath(name: string) {
-  if (existsSync(`${COMPLETE_DOWNLOAD_ROOT}/${name}`)) {
-    return `${COMPLETE_DOWNLOAD_ROOT}/${name}`
-  }
-
-  if (existsSync(`${SHARED_DOWNLOAD_ROOT}/${name}`)) {
-    return `${SHARED_DOWNLOAD_ROOT}/${name}`
+export function resolveContentPath(fileName: string): string | undefined {
+  for (const root of [
+    COMPLETE_DOWNLOAD_ROOT,
+    SHARED_DOWNLOAD_ROOT,
+    INCOMPLETE_DOWNLOAD_ROOT,
+  ]) {
+    const safePath = resolveSafeFilePath(root, fileName)
+    if (safePath && existsSync(safePath)) {
+      return safePath
+    }
   }
 
   return undefined
@@ -55,9 +61,8 @@ export function buildQbittorrentTorrentInfo(file: DownloadClientFile) {
   const completed = file.progress >= 1
   const progress =
     file.progress === 1 ? 1 : Math.min(0.999, Math.max(file.progress, 0.001))
-  const addedOn = file.meta?.addedOn
-  const completionOn = file.meta?.completionOn
-  const path = contentPath(file.name)
+  const timestamps = torrentTimestampsFromMetadata(file.meta)
+  const path = resolveContentPath(file.name)
 
   return {
     hash: externalHash,
@@ -75,10 +80,41 @@ export function buildQbittorrentTorrentInfo(file: DownloadClientFile) {
     save_path: QBITTORRENT_SAVE_PATH,
     content_path: path,
     ratio: completed ? COMPLETED_COMPAT_RATIO : INCOMPLETE_COMPAT_RATIO,
-    seeding_time: completed ? 86400 : 0,
-    added_on: timestampToUnixSeconds(addedOn),
-    completion_on: completed ? timestampToUnixSeconds(completionOn) : 0,
+    seeding_time: completed ? COMPLETED_SEEDING_TIME_SECONDS : 0,
+    added_on: timestamps.added_on,
+    completion_on: completed ? timestamps.completion_on : 0,
     priority: 1,
+  }
+}
+
+export function buildQbittorrentTorrentProperties(file: DownloadClientFile) {
+  const timestamps = torrentTimestampsFromMetadata(file.meta)
+
+  return {
+    save_path: QBITTORRENT_SAVE_PATH,
+    creation_date: 0,
+    piece_size: 0,
+    comment: "",
+    total_wasted: 0,
+    total_uploaded: 0,
+    total_uploaded_session: 0,
+    total_downloaded: file.size_done,
+    total_downloaded_session: file.size_done,
+    up_limit: -1,
+    dl_limit: -1,
+    time_elapsed: 0,
+    nb_connections: 0,
+    nb_connections_limit: 100,
+    share_ratio: file.progress >= 1 ? 1 : 0,
+    addition_date: timestamps.addition_date,
+    completion_date: file.progress >= 1 ? timestamps.completion_date : 0,
+    created_by: "eMulerr",
+    dl_speed_avg: file.speed ?? 0,
+    dl_speed: file.speed ?? 0,
+    eta: file.eta,
+    last_seen: 0,
+    peers: 0,
+    seeds: 0,
   }
 }
 
@@ -95,20 +131,5 @@ export function buildQbittorrentTorrentFile(file: DownloadClientFile) {
     priority: 1,
     is_seed: completed,
     availability: completed ? 1 : 0,
-  }
-}
-
-export function ensureCompletionOn(
-  hash: string,
-  meta: HashMetadata | undefined,
-  completed: boolean
-): HashMetadata | undefined {
-  if (!meta || !completed || meta.completionOn !== undefined) {
-    return meta
-  }
-
-  return {
-    ...meta,
-    completionOn: Date.now(),
   }
 }

--- a/src/app/utils/qbittorrentTorrentResponse.ts
+++ b/src/app/utils/qbittorrentTorrentResponse.ts
@@ -1,0 +1,114 @@
+import { existsSync } from "node:fs"
+import { amuleGetDownloads } from "amule/amule"
+import {
+  COMPLETE_DOWNLOAD_ROOT,
+  SHARED_DOWNLOAD_ROOT,
+} from "~/utils/qbittorrentPathSafety"
+import { internalToExternalQbittorrentHash } from "~/utils/qbittorrentHash"
+import { timestampToUnixSeconds } from "~/utils/qbittorrentTimestamps"
+import type { DownloadClientFile, HashMetadata } from "~/data/downloadClient"
+
+export const QBITTORRENT_SAVE_PATH = COMPLETE_DOWNLOAD_ROOT
+
+// LazyLibrarian treats pausedUP/stoppedUP items as finished only when max_ratio > 0.
+// aMule has no BitTorrent ratio; completed eD2K items always expose ratio 1.0.
+export const COMPLETED_COMPAT_RATIO = 1.0
+export const INCOMPLETE_COMPAT_RATIO = 0.0
+
+export function statusToQbittorrentState(
+  status: Awaited<ReturnType<typeof amuleGetDownloads>>[0]["status_str"]
+) {
+  switch (status) {
+    case "downloading":
+      return "downloading"
+    case "downloaded":
+      return "pausedUP"
+    case "stalled":
+      return "stalledDL"
+    case "error":
+      return "error"
+    case "completing":
+      return "moving"
+    case "stopped":
+      return "pausedDL"
+  }
+}
+
+function contentPath(name: string) {
+  if (existsSync(`${COMPLETE_DOWNLOAD_ROOT}/${name}`)) {
+    return `${COMPLETE_DOWNLOAD_ROOT}/${name}`
+  }
+
+  if (existsSync(`${SHARED_DOWNLOAD_ROOT}/${name}`)) {
+    return `${SHARED_DOWNLOAD_ROOT}/${name}`
+  }
+
+  return undefined
+}
+
+export function buildQbittorrentTorrentInfo(file: DownloadClientFile) {
+  const externalHash = internalToExternalQbittorrentHash(file.hash)
+  if (!externalHash) {
+    return null
+  }
+
+  const completed = file.progress >= 1
+  const progress =
+    file.progress === 1 ? 1 : Math.min(0.999, Math.max(file.progress, 0.001))
+  const addedOn = file.meta?.addedOn
+  const completionOn = file.meta?.completionOn
+  const path = contentPath(file.name)
+
+  return {
+    hash: externalHash,
+    name: file.name,
+    size: file.size,
+    total_size: file.size,
+    downloaded: file.size_done,
+    completed: file.size_done,
+    progress,
+    dlspeed: file.speed ?? 0,
+    upspeed: file.up_speed ?? 0,
+    eta: file.eta,
+    state: statusToQbittorrentState(file.status_str),
+    category: file.meta?.category ?? "",
+    save_path: QBITTORRENT_SAVE_PATH,
+    content_path: path,
+    ratio: completed ? COMPLETED_COMPAT_RATIO : INCOMPLETE_COMPAT_RATIO,
+    seeding_time: completed ? 86400 : 0,
+    added_on: timestampToUnixSeconds(addedOn),
+    completion_on: completed ? timestampToUnixSeconds(completionOn) : 0,
+    priority: 1,
+  }
+}
+
+export function buildQbittorrentTorrentFile(file: DownloadClientFile) {
+  const completed = file.progress >= 1
+  const progress =
+    file.progress === 1 ? 1 : Math.min(0.999, Math.max(file.progress, 0.001))
+
+  return {
+    index: 0,
+    name: file.name,
+    size: file.size,
+    progress,
+    priority: 1,
+    is_seed: completed,
+    availability: completed ? 1 : 0,
+  }
+}
+
+export function ensureCompletionOn(
+  hash: string,
+  meta: HashMetadata | undefined,
+  completed: boolean
+): HashMetadata | undefined {
+  if (!meta || !completed || meta.completionOn !== undefined) {
+    return meta
+  }
+
+  return {
+    ...meta,
+    completionOn: Date.now(),
+  }
+}

--- a/src/app/utils/qbittorrentTorrentResponse.ts
+++ b/src/app/utils/qbittorrentTorrentResponse.ts
@@ -133,3 +133,14 @@ export function buildQbittorrentTorrentFile(file: DownloadClientFile) {
     availability: completed ? 1 : 0,
   }
 }
+
+export const QBITTORRENT_APP_PREFERENCES = {
+  save_path: QBITTORRENT_SAVE_PATH,
+  temp_path_enabled: true,
+  temp_path: "/downloads/incomplete",
+  create_subfolder_enabled: false,
+  max_ratio_enabled: true,
+  max_ratio: COMPLETED_COMPAT_RATIO,
+  max_seeding_time_enabled: true,
+  max_seeding_time: COMPLETED_SEEDING_TIME_SECONDS,
+}

--- a/src/app/utils/qbittorrentTorrentResponse.ts
+++ b/src/app/utils/qbittorrentTorrentResponse.ts
@@ -7,6 +7,7 @@ import {
   SHARED_DOWNLOAD_ROOT,
 } from "~/utils/qbittorrentPathSafety"
 import { internalToExternalQbittorrentHash } from "~/utils/qbittorrentHash"
+import { logger } from "~/utils/logger"
 import { torrentTimestampsFromMetadata } from "~/utils/qbittorrentTimestamps"
 import type { DownloadClientFile } from "~/data/downloadClient"
 
@@ -55,6 +56,10 @@ export function resolveContentPath(fileName: string): string | undefined {
 export function buildQbittorrentTorrentInfo(file: DownloadClientFile) {
   const externalHash = internalToExternalQbittorrentHash(file.hash)
   if (!externalHash) {
+    logger.warn("Skipping torrent info entry with non-exportable hash", {
+      hash: file.hash,
+      name: file.name,
+    })
     return null
   }
 

--- a/src/app/utils/qbittorrentTorrentState.ts
+++ b/src/app/utils/qbittorrentTorrentState.ts
@@ -5,6 +5,7 @@ import {
 } from "~/data/downloadClient"
 import {
   parseTorrentHashesFromFormData,
+  selectionFromParsedHashes,
   type ParsedQbittorrentHashSelection,
 } from "~/utils/qbittorrentHash"
 import { logger } from "~/utils/logger"
@@ -14,20 +15,13 @@ export type { ParsedQbittorrentHashSelection as ParsedTorrentHashes }
 export {
   parseTorrentHashesFromFormData,
   parseQbittorrentHashSelection,
+  parseQbittorrentHashQuery,
 } from "~/utils/qbittorrentHash"
 
 function toTorrentHashSelection(
   parsed: ParsedQbittorrentHashSelection
 ): TorrentHashSelection | null {
-  if (parsed.kind === "none") {
-    return null
-  }
-
-  if (parsed.kind === "all") {
-    return "all"
-  }
-
-  return parsed.hashes
+  return selectionFromParsedHashes(parsed)
 }
 
 function rejectNonPostMethod(): Response {

--- a/src/app/utils/qbittorrentTorrentState.ts
+++ b/src/app/utils/qbittorrentTorrentState.ts
@@ -40,8 +40,13 @@ export function parseTorrentHashesFromFormData(
         .map((part) => part.trim())
         .filter(Boolean)
         .map(normalizeQbittorrentHash)
+        .filter((hash) => /^[0-9A-F]{32}$/.test(hash))
     ),
   ]
+
+  if (!hashes.length) {
+    return { kind: "none" }
+  }
 
   return { kind: "hashes", hashes }
 }

--- a/src/app/utils/qbittorrentTorrentState.ts
+++ b/src/app/utils/qbittorrentTorrentState.ts
@@ -1,5 +1,8 @@
-import { amuleGetDownloads } from "amule/amule"
-import { pauseTorrents, resumeTorrents } from "~/data/downloadClient"
+import {
+  pauseTorrents,
+  resumeTorrents,
+  type TorrentHashSelection,
+} from "~/data/downloadClient"
 import { logger } from "~/utils/logger"
 
 export type ParsedTorrentHashes =
@@ -51,16 +54,15 @@ export function parseTorrentHashesFromFormData(
   return { kind: "hashes", hashes }
 }
 
-export async function resolveTorrentHashes(
+function toTorrentHashSelection(
   parsed: ParsedTorrentHashes
-): Promise<string[]> {
+): TorrentHashSelection | null {
   if (parsed.kind === "none") {
-    return []
+    return null
   }
 
   if (parsed.kind === "all") {
-    const downloads = await amuleGetDownloads()
-    return downloads.map((download) => download.hash)
+    return "all"
   }
 
   return parsed.hashes
@@ -93,13 +95,13 @@ export async function handleTorrentStateAction(
   logger.debug("Path", url.pathname)
   const formData = await readTorrentStateFormData(request)
   const parsed = parseTorrentHashesFromFormData(formData)
-  const hashes = await resolveTorrentHashes(parsed)
+  const selection = toTorrentHashSelection(parsed)
 
-  if (hashes.length) {
+  if (selection) {
     if (state === "pause") {
-      await pauseTorrents(hashes)
+      await pauseTorrents(selection)
     } else {
-      await resumeTorrents(hashes)
+      await resumeTorrents(selection)
     }
   }
 

--- a/src/app/utils/qbittorrentTorrentState.ts
+++ b/src/app/utils/qbittorrentTorrentState.ts
@@ -18,7 +18,7 @@ export function normalizeQbittorrentHash(raw: string): string {
 export function parseTorrentHashesFromFormData(
   formData: FormData
 ): ParsedTorrentHashes {
-  const hashesRaw = formData.get("hashes")?.toString()
+  const hashesRaw = formData.get("hashes")?.toString().trim()
   if (!hashesRaw) {
     return { kind: "none" }
   }
@@ -55,10 +55,21 @@ export async function resolveTorrentHashes(
   return parsed.hashes
 }
 
+function rejectNonPostMethod(): Response {
+  return new Response(null, {
+    status: 405,
+    headers: { Allow: "POST" },
+  })
+}
+
 export async function handleTorrentStateAction(
   request: Request,
   state: "pause" | "resume"
 ): Promise<Response> {
+  if (request.method !== "POST") {
+    return rejectNonPostMethod()
+  }
+
   logger.debug("URL", request.url)
   const formData = await request.formData()
   const parsed = parseTorrentHashesFromFormData(formData)
@@ -76,5 +87,5 @@ export async function handleTorrentStateAction(
 }
 
 export function rejectTorrentStateGet(): Response {
-  return new Response(null, { status: 405 })
+  return rejectNonPostMethod()
 }

--- a/src/app/utils/qbittorrentTorrentState.ts
+++ b/src/app/utils/qbittorrentTorrentState.ts
@@ -1,0 +1,80 @@
+import { amuleGetDownloads } from "amule/amule"
+import { pauseTorrents, resumeTorrents } from "~/data/downloadClient"
+import { logger } from "~/utils/logger"
+
+export type ParsedTorrentHashes =
+  | { kind: "none" }
+  | { kind: "all" }
+  | { kind: "hashes"; hashes: string[] }
+
+export function normalizeQbittorrentHash(raw: string): string {
+  const hash = raw.trim().toUpperCase()
+  if (/^[0-9A-F]{40}$/.test(hash) && hash.endsWith("00000000")) {
+    return hash.slice(0, 32)
+  }
+  return hash
+}
+
+export function parseTorrentHashesFromFormData(
+  formData: FormData
+): ParsedTorrentHashes {
+  const hashesRaw = formData.get("hashes")?.toString()
+  if (!hashesRaw) {
+    return { kind: "none" }
+  }
+
+  if (hashesRaw.toLowerCase() === "all") {
+    return { kind: "all" }
+  }
+
+  const hashes = [
+    ...new Set(
+      hashesRaw
+        .split("|")
+        .map((part) => part.trim())
+        .filter(Boolean)
+        .map(normalizeQbittorrentHash)
+    ),
+  ]
+
+  return { kind: "hashes", hashes }
+}
+
+export async function resolveTorrentHashes(
+  parsed: ParsedTorrentHashes
+): Promise<string[]> {
+  if (parsed.kind === "none") {
+    return []
+  }
+
+  if (parsed.kind === "all") {
+    const downloads = await amuleGetDownloads()
+    return downloads.map((download) => download.hash)
+  }
+
+  return parsed.hashes
+}
+
+export async function handleTorrentStateAction(
+  request: Request,
+  state: "pause" | "resume"
+): Promise<Response> {
+  logger.debug("URL", request.url)
+  const formData = await request.formData()
+  const parsed = parseTorrentHashesFromFormData(formData)
+  const hashes = await resolveTorrentHashes(parsed)
+
+  if (hashes.length) {
+    if (state === "pause") {
+      await pauseTorrents(hashes)
+    } else {
+      await resumeTorrents(hashes)
+    }
+  }
+
+  return new Response(null, { status: 200 })
+}
+
+export function rejectTorrentStateGet(): Response {
+  return new Response(null, { status: 405 })
+}

--- a/src/app/utils/qbittorrentTorrentState.ts
+++ b/src/app/utils/qbittorrentTorrentState.ts
@@ -3,59 +3,21 @@ import {
   resumeTorrents,
   type TorrentHashSelection,
 } from "~/data/downloadClient"
+import {
+  parseTorrentHashesFromFormData,
+  type ParsedQbittorrentHashSelection,
+} from "~/utils/qbittorrentHash"
 import { logger } from "~/utils/logger"
 
-export type ParsedTorrentHashes =
-  | { kind: "none" }
-  | { kind: "all" }
-  | { kind: "hashes"; hashes: string[] }
+export type { ParsedQbittorrentHashSelection as ParsedTorrentHashes }
 
-export function normalizeQbittorrentHash(raw: string): string {
-  const hash = raw.trim().toUpperCase()
-  if (/^[0-9A-F]{40}$/.test(hash) && hash.endsWith("00000000")) {
-    return hash.slice(0, 32)
-  }
-  return hash
-}
-
-export function parseTorrentHashesFromFormData(
-  formData: FormData
-): ParsedTorrentHashes {
-  const hashesValue = formData.get("hashes")
-
-  if (typeof hashesValue !== "string") {
-    return { kind: "none" }
-  }
-
-  const hashesRaw = hashesValue.trim()
-  if (!hashesRaw) {
-    return { kind: "none" }
-  }
-
-  if (hashesRaw.toLowerCase() === "all") {
-    return { kind: "all" }
-  }
-
-  const hashes = [
-    ...new Set(
-      hashesRaw
-        .split("|")
-        .map((part) => part.trim())
-        .filter(Boolean)
-        .map(normalizeQbittorrentHash)
-        .filter((hash) => /^[0-9A-F]{32}$/.test(hash))
-    ),
-  ]
-
-  if (!hashes.length) {
-    return { kind: "none" }
-  }
-
-  return { kind: "hashes", hashes }
-}
+export {
+  parseTorrentHashesFromFormData,
+  parseQbittorrentHashSelection,
+} from "~/utils/qbittorrentHash"
 
 function toTorrentHashSelection(
-  parsed: ParsedTorrentHashes
+  parsed: ParsedQbittorrentHashSelection
 ): TorrentHashSelection | null {
   if (parsed.kind === "none") {
     return null

--- a/src/app/utils/qbittorrentTorrentState.ts
+++ b/src/app/utils/qbittorrentTorrentState.ts
@@ -18,7 +18,13 @@ export function normalizeQbittorrentHash(raw: string): string {
 export function parseTorrentHashesFromFormData(
   formData: FormData
 ): ParsedTorrentHashes {
-  const hashesRaw = formData.get("hashes")?.toString().trim()
+  const hashesValue = formData.get("hashes")
+
+  if (typeof hashesValue !== "string") {
+    return { kind: "none" }
+  }
+
+  const hashesRaw = hashesValue.trim()
   if (!hashesRaw) {
     return { kind: "none" }
   }

--- a/src/app/utils/qbittorrentTorrentState.ts
+++ b/src/app/utils/qbittorrentTorrentState.ts
@@ -62,6 +62,14 @@ function rejectNonPostMethod(): Response {
   })
 }
 
+async function readTorrentStateFormData(request: Request): Promise<FormData> {
+  try {
+    return await request.formData()
+  } catch {
+    return new FormData()
+  }
+}
+
 export async function handleTorrentStateAction(
   request: Request,
   state: "pause" | "resume"
@@ -70,8 +78,9 @@ export async function handleTorrentStateAction(
     return rejectNonPostMethod()
   }
 
-  logger.debug("URL", request.url)
-  const formData = await request.formData()
+  const url = new URL(request.url)
+  logger.debug("Path", url.pathname)
+  const formData = await readTorrentStateFormData(request)
   const parsed = parseTorrentHashesFromFormData(formData)
   const hashes = await resolveTorrentHashes(parsed)
 

--- a/src/app/utils/state.ts
+++ b/src/app/utils/state.ts
@@ -28,10 +28,12 @@ export function deepFreeze<T>(obj: T): T {
     try {
         // Freeze self
         Object.freeze(obj);
-    } catch { }
+    } catch {
+        // Some objects cannot be frozen in every runtime.
+    }
 
     Object.getOwnPropertyNames(obj).forEach((name) => {
-        const prop = (obj as any)[name];
+        const prop = (obj as Record<string, unknown>)[name];
         const type = typeof prop;
 
         // Freeze prop if it is an object or function and also not already frozen

--- a/src/app/utils/torznabFeed.test.ts
+++ b/src/app/utils/torznabFeed.test.ts
@@ -90,4 +90,28 @@ describe("torznabFeed publication support", () => {
     assert.match(xml, /Revue été 2024\.pdf/)
     assertWellFormedRss(xml)
   })
+
+  it("joins multiple items without comma separators", () => {
+    const trickyName = 'Hackable & "N°02".pdf'
+    const trickyMagnet =
+      "magnet:?xt=urn:btih:abc&dn=Hackable%20%26%20Test&tr=http://emulerr"
+    const xml = itemsResponse(
+      [
+        sampleItem("Hackable Magazine 01.pdf"),
+        {
+          ...sampleItem(trickyName),
+          magnetLink: trickyMagnet,
+        },
+      ],
+      [7000]
+    )
+
+    const itemCount = (xml.match(/<item>/g) ?? []).length
+    assert.equal(itemCount, 2)
+    assert.doesNotMatch(xml, /<\/item>,\s*<item>/)
+    assert.match(xml, /Hackable Magazine 01\.pdf/)
+    assert.match(xml, /Hackable &amp; &quot;N°02&quot;\.pdf/)
+    assert.match(xml, /value="magnet:\?xt=urn:btih:abc&amp;dn=/)
+    assertWellFormedRss(xml)
+  })
 })

--- a/src/app/utils/torznabFeed.test.ts
+++ b/src/app/utils/torznabFeed.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { hasAllowedExtension, itemsResponse } from "./torznabFeed.ts"
+
+const SAMPLE_HASH = "A1B2C3D4E5F6789012345678ABCDEF01"
+const MAGNET = `magnet:?xt=urn:btih:${SAMPLE_HASH.toLowerCase()}00000000&dn=test&tr=http://emulerr`
+
+function sampleItem(name: string) {
+  return {
+    name,
+    short_name: name,
+    hash: SAMPLE_HASH,
+    size: 42,
+    sources: 3,
+    present: false,
+    magnetLink: MAGNET,
+    ed2kLink: "ed2k://example",
+  }
+}
+
+function assertWellFormedRss(xml: string) {
+  assert.match(xml, /<rss version="2\.0"/)
+  assert.match(xml, /<channel>/)
+  assert.match(xml, /<\/channel>/)
+  assert.match(xml, /<\/rss>/)
+  assert.doesNotMatch(xml, /<(title|link|enclosure)[^>]*>[^<]*&[^a][^;]*</)
+}
+
+describe("torznabFeed publication support", () => {
+  it("accepts video extensions", () => {
+    for (const name of ["clip.mp4", "movie.MKV", "show.AVI"]) {
+      assert.equal(hasAllowedExtension(name), true, name)
+    }
+  })
+
+  it("accepts publication extensions case-insensitively", () => {
+    for (const name of [
+      "issue.pdf",
+      "book.EPUB",
+      "novel.MOBI",
+      "reader.AZW3",
+      "comic.CBZ",
+      "archive.CBR",
+      "bundle.ZIP",
+      "collection.RAR",
+    ]) {
+      assert.equal(hasAllowedExtension(name), true, name)
+    }
+  })
+
+  it("rejects unknown extensions and extensionless names", () => {
+    for (const name of ["readme.txt", "binary", "Hackable Magazine N°30"]) {
+      assert.equal(hasAllowedExtension(name), false, name)
+    }
+  })
+
+  it("includes link, enclosure and magneturl in Torznab items", () => {
+    const xml = itemsResponse([sampleItem("Hackable Magazine 01.PDF")], [7000])
+    assert.match(xml, /<link>.*magnet:\?xt=urn:btih:/)
+    assert.match(xml, /<enclosure url=".*magnet:\?xt=urn:btih:/)
+    assert.match(
+      xml,
+      /<torznab:attr name="magneturl" value=".*magnet:\?xt=urn:btih:/
+    )
+    assertWellFormedRss(xml)
+  })
+
+  it("escapes XML special characters in titles and magnet attributes", () => {
+    const trickyName = 'Hackable & "Spécial" <01>.pdf'
+    const trickyMagnet =
+      "magnet:?xt=urn:btih:abc&dn=Hackable%20%26%20Test&tr=http://emulerr"
+    const xml = itemsResponse(
+      [
+        {
+          ...sampleItem(trickyName),
+          magnetLink: trickyMagnet,
+        },
+      ],
+      [7000]
+    )
+
+    assert.match(xml, /Hackable &amp; &quot;Spécial&quot; &lt;01&gt;\.pdf/)
+    assert.match(xml, /value="magnet:\?xt=urn:btih:abc&amp;dn=/)
+    assert.doesNotMatch(xml, /<title>Hackable & /)
+    assertWellFormedRss(xml)
+  })
+
+  it("keeps unicode publication names in valid Torznab output", () => {
+    const xml = itemsResponse([sampleItem("Revue été 2024.pdf")], [7000])
+    assert.match(xml, /Revue été 2024\.pdf/)
+    assertWellFormedRss(xml)
+  })
+})

--- a/src/app/utils/torznabFeed.ts
+++ b/src/app/utils/torznabFeed.ts
@@ -32,8 +32,9 @@ export const itemsResponse = (
   <rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
     <channel>
       <torznab:response offset="0" total="${searchResults.length}"/>
-      ${searchResults.map(
-        (item) => `
+      ${searchResults
+        .map(
+          (item) => `
           <item>
             <title>${encode(item.name)}</title>
             <guid>${item.hash}-${encode(item.name)}</guid>
@@ -50,7 +51,8 @@ export const itemsResponse = (
             <torznab:attr name="minimumseedtime" value="0" />
             <torznab:attr name="tag" value="freeleech" />
           </item>`
-      )}
+        )
+        .join("")}
     </channel>
   </rss>
   `

--- a/src/app/utils/torznabFeed.ts
+++ b/src/app/utils/torznabFeed.ts
@@ -1,0 +1,56 @@
+import { encode } from "html-entities"
+import { buildRFC822Date } from "./time"
+
+const VIDEO_EXTENSIONS = ["mp4", "mkv", "avi", "wmv", "mpeg", "mpg"]
+const PUBLICATION_EXTENSIONS = [
+  "pdf",
+  "epub",
+  "mobi",
+  "azw3",
+  "cbz",
+  "cbr",
+  "zip",
+  "rar",
+]
+const TORZNAB_EXTENSIONS = [...VIDEO_EXTENSIONS, ...PUBLICATION_EXTENSIONS]
+
+export function hasAllowedExtension(filename: string) {
+  const lower = filename.toLowerCase()
+  return TORZNAB_EXTENSIONS.some((ext) => lower.endsWith(`.${ext}`))
+}
+
+export const itemsResponse = (
+  searchResults: Array<{
+    name: string
+    hash: string
+    size: number
+    sources: number
+    magnetLink: string
+  }>,
+  categories: number[]
+) => `
+  <rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+    <channel>
+      <torznab:response offset="0" total="${searchResults.length}"/>
+      ${searchResults.map(
+        (item) => `
+          <item>
+            <title>${encode(item.name)}</title>
+            <guid>${item.hash}-${encode(item.name)}</guid>
+            <link>${encode(item.magnetLink)}</link>
+            <pubDate>${buildRFC822Date(new Date())}</pubDate>
+            <enclosure url="${encode(item.magnetLink)}" length="${item.size}" type="application/x-bittorrent" />
+            <torznab:attr name="magneturl" value="${encode(item.magnetLink)}" />
+            <torznab:attr name="size" value="${item.size}" />
+            ${categories.map((c) => `<torznab:attr name="category" value="${c}" />`).join("")}
+            <torznab:attr name="seeders" value="${item.sources}" />
+            <torznab:attr name="downloadvolumefactor" value="0" />
+            <torznab:attr name="uploadvolumefactor" value="0" />
+            <torznab:attr name="minimumratio" value="0" />
+            <torznab:attr name="minimumseedtime" value="0" />
+            <torznab:attr name="tag" value="freeleech" />
+          </item>`
+      )}
+    </channel>
+  </rss>
+  `

--- a/src/app/utils/types.ts
+++ b/src/app/utils/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { ActionFunctionArgs, LoaderFunctionArgs, TypedDeferredData } from "@remix-run/node";
 
 export type ActionOrLoaderReturnType<T extends (args: LoaderFunctionArgs | ActionFunctionArgs) => Promise<{ json(): Promise<any> }>> = Awaited<ReturnType<Awaited<ReturnType<T>>['json']>>

--- a/src/app/utils/useRevalidate.ts
+++ b/src/app/utils/useRevalidate.ts
@@ -17,5 +17,5 @@ export function useRevalidate(enabled: boolean, time: number) {
       const i = setInterval(revalidate, time)
       return () => clearInterval(i)
     }
-  }, [revalidate, enabled])
+  }, [revalidate, enabled, time])
 }

--- a/src/cron/cron.ts
+++ b/src/cron/cron.ts
@@ -19,6 +19,7 @@ const jobs = [
 
 // Using global as live reload will re-run the file, and variables get lost
 declare global {
+  // eslint-disable-next-line no-var -- global augmentation requires var
   var cronJobIntervalIds: NodeJS.Timeout[] | undefined
 }
 

--- a/src/cron/detectBrokenAmule.ts
+++ b/src/cron/detectBrokenAmule.ts
@@ -2,6 +2,7 @@ import { amuleGetCategories, restartAmule } from "amule/amule"
 import { Mutex } from "async-mutex"
 
 declare global {
+    // eslint-disable-next-line no-var -- global augmentation requires var
     var detectBrokenAmuleMutex: Mutex
 }
 

--- a/src/cron/resumePausedDownloads.ts
+++ b/src/cron/resumePausedDownloads.ts
@@ -1,8 +1,10 @@
 import { amuleDoResume, amuleGetDownloads } from "amule/amule"
+import { metadataDb } from "~/data/downloadClient"
 import { Mutex } from "async-mutex"
 import { logger } from "~/utils/logger"
 
 declare global {
+    // eslint-disable-next-line no-var -- TypeScript global augmentation requires var
     var resumePausedDownloadsMutex: Mutex
 }
 
@@ -15,7 +17,10 @@ export async function resumePausedDownloads() {
 
     await globalThis.resumePausedDownloadsMutex.runExclusive(async () => {
         const downloads = await amuleGetDownloads()
-        const stoppedDownloads = downloads.filter(d => d.status_str === 'stopped')
+        const stoppedDownloads = downloads.filter(
+          (d) =>
+            d.status_str === "stopped" && !metadataDb.data[d.hash]?.pausedByApi
+        )
         if (!stoppedDownloads.length) {
             return
         }

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -62,6 +62,7 @@
         "prettier": "^3.2.5",
         "prettier-plugin-tailwindcss": "^0.5.12",
         "tailwindcss": "^3.4.1",
+        "tsx": "^4.22.4",
         "typescript": "^5.4.5",
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^5.1.0",
@@ -208,7 +209,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.0.tgz",
       "integrity": "sha512-fQfkg0Gjkza3nf0c7/w6Xf34BW4YvzNfACRLmmb7XRLa6XHdR+K9AlJlxneFfWYf6uhOzuzZVTjF/8KfndZANw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.23.5",
@@ -1073,6 +1073,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.17.6",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.6.tgz",
@@ -1089,6 +1106,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.17.6",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.6.tgz",
@@ -1103,6 +1137,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -1705,7 +1756,6 @@
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.9.1.tgz",
       "integrity": "sha512-shicVsSmXepj4zotWHR2kLmyYCxQ25mHmfBL11ODIcIs7iSmQO+W7CNbmX1jcRvhHki/v+S/n4fMm0iKNeJ92w==",
-      "peer": true,
       "dependencies": {
         "@remix-run/server-runtime": "2.9.1",
         "@remix-run/web-fetch": "^4.4.2",
@@ -1731,7 +1781,6 @@
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.9.1.tgz",
       "integrity": "sha512-QQVZPS56okvDF3FBuGBjyKuYa6bXZvXFFlYeWfngI8ZnDbCzQLKV1oD0FWMhKuQxMaKs25uWg2YwGqwWTdin3w==",
-      "peer": true,
       "dependencies": {
         "@remix-run/router": "1.16.0",
         "@remix-run/server-runtime": "2.9.1",
@@ -1765,7 +1814,6 @@
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.9.1.tgz",
       "integrity": "sha512-6rRPiR+eMdTPkDojlYiZohVzXkD3+3X55ZvD78axMVocwGcDFFllpmgH9NSR2RKHW9eZDZUfKvNCwd/i9W6Xog==",
-      "peer": true,
       "dependencies": {
         "@remix-run/router": "1.16.0",
         "@types/cookie": "^0.6.0",
@@ -2221,7 +2269,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.66.tgz",
       "integrity": "sha512-OYTmMI4UigXeFMF/j4uv0lBBEbongSgptPrHBxqME44h9+yNov+oL6Z3ocJKo0WyXR84sQUNeyIp9MRfckvZpg==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -2335,7 +2382,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2601,7 +2647,6 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3163,7 +3208,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001587",
         "electron-to-chromium": "^1.4.668",
@@ -3468,6 +3512,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
       "integrity": "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==",
+      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "@types/estree": "^1.0.1",
@@ -3711,6 +3756,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
       "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "peer": true,
       "dependencies": {
         "mdn-data": "2.0.30",
         "source-map-js": "^1.0.1"
@@ -4226,7 +4272,6 @@
       "integrity": "sha512-TKFRp9TxrJDdRWfSsSERKEovm6v30iHnrjlcGhLBOtReE28Yp1VSBRfO3GTaOFMoxsNerx4TjrhzSuma9ha83Q==",
       "dev": true,
       "hasInstallScript": true,
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4306,7 +4351,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4433,7 +4477,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
       "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.7",
         "array.prototype.findlastindex": "^1.2.3",
@@ -5010,7 +5053,6 @@
       "version": "4.19.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
       "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -5890,7 +5932,6 @@
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
       "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -6825,7 +6866,8 @@
     "node_modules/locate-character": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
-      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "peer": true
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -6937,6 +6979,7 @@
       "version": "0.30.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.9.tgz",
       "integrity": "sha512-S1+hd+dIrC8EZqKyT9DstTH/0Z+f76kmmvZnkfQVmOpDEF9iVgdYif3Q/pIWHmCoo59bQVGW0kVL3e2nl+9+Sw==",
+      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
       },
@@ -7187,7 +7230,8 @@
     "node_modules/mdn-data": {
       "version": "2.0.30",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+      "peer": true
     },
     "node_modules/media-query-parser": {
       "version": "2.0.2",
@@ -8885,7 +8929,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -9108,7 +9151,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
       "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9378,7 +9420,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9390,7 +9431,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -9664,7 +9704,6 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/remix-validated-form/-/remix-validated-form-5.1.5.tgz",
       "integrity": "sha512-v27JGzhOMGREyvPIDAgjhywfVYahe3CC4EXGIzJbwZfXnq7GFju5f/yNmyUyQLeYcOmU6uhzq+vwDJDOiXjvBA==",
-      "peer": true,
       "dependencies": {
         "immer": "^9.0.12",
         "lodash.get": "^4.4.2",
@@ -10641,6 +10680,7 @@
       "version": "4.2.13",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.13.tgz",
       "integrity": "sha512-jtVt2KXLbQnsWN93Zd7EVboNh8Tqexes4rZfXNP7nYRjd9+JjubTD8BXloUmU1OUYpc6pdd1aKBhCV+b2ZKoMg==",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
@@ -10665,6 +10705,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.0.0.tgz",
       "integrity": "sha512-+60uv1hiVFhHZeO+Lz0RYzsVHy5Wr1ayX0mwda9KPDVLNJgZ1T9Ny7VmFbLDzxsH0D87I86vgj3gFrjTJUYznw==",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -11032,6 +11073,458 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/turbo-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.0.1.tgz",
@@ -11151,7 +11644,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "devOptional": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12368,7 +12860,6 @@
       "version": "3.22.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
       "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/package.json
+++ b/src/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint --resolve-plugins-relative-to . --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
     "start": "cross-env NODE_ENV=production node ./server.js",
     "typecheck": "tsc",
-    "test": "tsx --test app/utils/qbittorrentHash.test.ts app/utils/qbittorrentMagnet.test.ts app/utils/qbittorrentBoolean.test.ts app/utils/qbittorrentTimestamps.test.ts app/utils/qbittorrentPathSafety.test.ts app/utils/qbittorrentDeletion.test.ts app/utils/qbittorrentTorrentResponse.test.ts app/utils/torznabFeed.test.ts"
+    "test": "tsx --test app/utils/qbittorrentHash.test.ts app/utils/qbittorrentMagnet.test.ts app/utils/qbittorrentBoolean.test.ts app/utils/qbittorrentTimestamps.test.ts app/utils/qbittorrentPathSafety.test.ts app/utils/qbittorrentDeletion.test.ts app/utils/qbittorrentTorrentResponse.test.ts app/utils/qbittorrentTorrentAdd.test.ts app/utils/torznabFeed.test.ts"
   },
   "dependencies": {
     "@bobthered/tailwindcss-palette-generator": "^3.2.3",

--- a/src/package.json
+++ b/src/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "build": "npm run typecheck && remix vite:build",
     "dev": "node ./server.js",
-    "lint": "eslint --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
+    "lint": "eslint --resolve-plugins-relative-to . --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
     "start": "cross-env NODE_ENV=production node ./server.js",
     "typecheck": "tsc",
-    "test": "tsx --test app/utils/qbittorrentHash.test.ts app/utils/qbittorrentMagnet.test.ts app/utils/qbittorrentBoolean.test.ts app/utils/qbittorrentTimestamps.test.ts app/utils/qbittorrentPathSafety.test.ts"
+    "test": "tsx --test app/utils/qbittorrentHash.test.ts app/utils/qbittorrentMagnet.test.ts app/utils/qbittorrentBoolean.test.ts app/utils/qbittorrentTimestamps.test.ts app/utils/qbittorrentPathSafety.test.ts app/utils/qbittorrentDeletion.test.ts app/utils/qbittorrentTorrentResponse.test.ts"
   },
   "dependencies": {
     "@bobthered/tailwindcss-palette-generator": "^3.2.3",

--- a/src/package.json
+++ b/src/package.json
@@ -8,7 +8,8 @@
     "dev": "node ./server.js",
     "lint": "eslint --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
     "start": "cross-env NODE_ENV=production node ./server.js",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "test": "tsx --test app/utils/qbittorrentHash.test.ts app/utils/qbittorrentMagnet.test.ts app/utils/qbittorrentBoolean.test.ts app/utils/qbittorrentTimestamps.test.ts app/utils/qbittorrentPathSafety.test.ts"
   },
   "dependencies": {
     "@bobthered/tailwindcss-palette-generator": "^3.2.3",
@@ -67,6 +68,7 @@
     "prettier": "^3.2.5",
     "prettier-plugin-tailwindcss": "^0.5.12",
     "tailwindcss": "^3.4.1",
+    "tsx": "^4.22.4",
     "typescript": "^5.4.5",
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^5.1.0",

--- a/src/package.json
+++ b/src/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint --resolve-plugins-relative-to . --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
     "start": "cross-env NODE_ENV=production node ./server.js",
     "typecheck": "tsc",
-    "test": "tsx --test app/utils/qbittorrentHash.test.ts app/utils/qbittorrentMagnet.test.ts app/utils/qbittorrentBoolean.test.ts app/utils/qbittorrentTimestamps.test.ts app/utils/qbittorrentPathSafety.test.ts app/utils/qbittorrentDeletion.test.ts app/utils/qbittorrentTorrentResponse.test.ts"
+    "test": "tsx --test app/utils/qbittorrentHash.test.ts app/utils/qbittorrentMagnet.test.ts app/utils/qbittorrentBoolean.test.ts app/utils/qbittorrentTimestamps.test.ts app/utils/qbittorrentPathSafety.test.ts app/utils/qbittorrentDeletion.test.ts app/utils/qbittorrentTorrentResponse.test.ts app/utils/torznabFeed.test.ts"
   },
   "dependencies": {
     "@bobthered/tailwindcss-palette-generator": "^3.2.3",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -7,6 +7,7 @@
     "**/.client/**/*.ts",
     "**/.client/**/*.tsx"
   ],
+  "exclude": ["**/*.test.ts"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "types": ["@remix-run/node", "vite/client"],


### PR DESCRIPTION
## Summary

Extends qBittorrent-compatible API coverage for PyMedusa state routes and for LazyLibrarian when downloading from eMulerr Torznab synthetic magnets.

Fixes #43

## Supported integration path

eMulerr Torznab result → synthetic magnet → LazyLibrarian qBittorrent client → eMulerr qBittorrent-compatible API → aMule/eD2K download → LazyLibrarian inspection/post-processing.

Genuine arbitrary BitTorrent `.torrent` files remain unsupported and return HTTP 415.

## Commits (15 ahead of upstream/main)

| Commit | Scope |
|---|---|
| `1fb5e07` | Medusa pause/stop/resume/start routes |
| `84e1ef7` | POST-only state routes, trim `hashes=all` |
| `fc62fe4` | Pathname-only logging, tolerant form parsing |
| `1e87362` | Reject non-string `hashes` form values |
| `37c0305` | Strict hash validation + active-download filtering |
| `4cdd677` | Single aMule download-list fetch for `hashes=all` |
| `1aa32a4` | LazyLibrarian qBittorrent API compatibility |
| `297a23e` | Edge-case hardening (timestamps, deletion, paths, magnets) |
| `3def393` | Torznab publication extensions + `link` / `magneturl` |
| `f6931e5` | Review fixes: multipart `File` rejection, nav a11y, shared preferences constant, Torznab tests |
| `831adc1` | Strict base32 synthetic BTIH hash lookup (`compatibilityHashToInternalEd2kHash`) |
| `164f882` | aMule `api.php` `$_GET` migration, `logger.warn` on bad hash export, `deleteFiles=false` comment |
| `a392066` | Torznab `.join("")`, ENOENT-tolerant `unlinkExistingFile()`, torrent-add parsing tests |
| `8a5c257` | PHP boundary hash validation for aMule `cancel`/`resume`/`pause` |
| `441c41a` | Reject non-string/`hash[]` values before `preg_match()` |

**HEAD:** `441c41ad17d98f9e1a137d82cdc58e4b3d220e7a`

## Strict compatibility hash lookup (`831adc1`)

Single canonical helper resolves these qBittorrent-compatible hash forms to the internal eD2K hash:

- **Internal:** 32-character eD2K hex
- **External padded:** 40-character hex ending in `00000000`
- **Synthetic base32 BTIH:** 32-character base32 (A–Z, 2–7) whose decoded trailing four bytes are zero

Arbitrary genuine BitTorrent info hashes remain rejected (non-zero padding, malformed base32, invalid lengths, unpadded 40-character hex).

Applies to `torrents/properties`, `torrents/files`, `torrents/info?hashes=`, and mutation routes via the shared hash-selection parser. API responses continue exposing lowercase 40-character padded hex hashes.

Reproduced mapping validated in unit tests:

- base32 `3ZXWM66ZHIOH7FHJZXMKSJFAW4AAAAAA`
- internal `DE6F667BD93A1C7F94E9CDD8A924A0B7`
- external `de6f667bd93a1c7f94e9cdd8a924a0b700000000`

## aMule and API response fixes (`164f882`)

- `src/amule/api.php`: replace deprecated `HTTP_GET_VARS` with `$_GET`
- `qbittorrentTorrentResponse.ts`: `logger.warn` when a torrent info hash cannot be exported
- `torrents/delete`: document `deleteFiles=false` semantics (cancel active download; completed files remain on disk)

## Copilot review fixes (`a392066`)

- **Torznab feed:** join mapped `<item>` XML with `.join("")` so multi-result feeds do not insert comma separators
- **Targeted deletion:** `unlinkExistingFile()` tolerates `ENOENT` (concurrent delete) and still propagates other errors
- **Torrent add:** `parseTorrentAddOptions()` extracted with tests; `paused`/`stopped` absent fields remain safe via optional chaining

## PHP boundary hash validation (`8a5c257`)

`get_valid_download_hash()` in `src/amule/api.php` validates `cancel`, `resume`, and `pause` commands:

- accepts only the canonical internal **32-character hexadecimal** eD2K hash (case-insensitive input, uppercase output)
- rejects missing, empty, short, long, non-hex, padded 40-character, base32 BTIH, and shell-metacharacter payloads with HTTP 400 `{"error":"invalid hash"}`
- does not call `amule_do_download_cmd()` for rejected input
- `441c41a`: rejects non-string/`hash[]` values before `preg_match()`

TypeScript continues to accept base32, padded external hex, and internal hex via `compatibilityHashToInternalEd2kHash()` and always forwards the normalized 32-character internal hash to aMule.

## Torznab publication support (`3def393`)

- Extensions: `pdf`, `epub`, `mobi`, `azw3`, `cbz`, `cbr`, `zip`, `rar` (case-insensitive) in addition to existing video types
- Each item exposes `<link>`, `<enclosure>`, and `torznab:attr name="magneturl"`

## Review fixes (`f6931e5`)

- `parseTorrentHashesFromFormData()` rejects multipart `File` values with `{ kind: "invalid" }` instead of coercing to `[object File]`
- Mobile nav backdrop is a labeled `<button>` with Space `preventDefault()`
- `max_seeding_time` preferences reuse `COMPLETED_SEEDING_TIME_SECONDS`
- Torznab feed logic extracted to `torznabFeed.ts` with focused unit tests

## Automated tests (HEAD `441c41a`, 2026-06-19)

Reproducible local checks from a clean workspace on branch `fix/qbittorrent-state-endpoints`:

| Check | Command | Result |
|---|---|---|
| Install | `cd src && npm ci` | pass |
| Typecheck | `npm run typecheck` | pass |
| Lint | `npm run lint` | pass |
| Unit tests | `npm run test` | **50/50 pass** |

Coverage includes hash selection (base32 BTIH), multipart form parsing, magnet parsing, timestamps, targeted deletion (ENOENT tolerance), torrent add options, torrent responses, preferences constants, and Torznab publication XML.

**PHP hash-boundary harness:** not re-run cleanly in this validation pass because the fresh Docker stack did not serve authenticated `api.php` JSON responses reliably (see Docker validation below). Prior harness work on this branch remains code-reviewed in `src/amule/api.php`; rerun is required before marking ready.

## Docker validation (HEAD `441c41a`, 2026-06-19)

Fresh production image built from current HEAD (no old `8a5c257` / `831adc1` tags reused):

```bash
docker build --no-cache -t emulerr:pr45-441c41a-fresh --build-arg IMG_VER=441c41a .
```

**Image digest:** `sha256:9ba584757966e0ba9b26865565d49017c596b759acebd5f963be580cc790bdba`

Runtime used fresh temporary Docker volumes (`emulerr-pr45-val-config`, `emulerr-pr45-val-complete`, `emulerr-pr45-val-incomplete`), not old validation containers/images/config.

### Passed on fresh stack

- `GET /health` → HTTP 200
- `POST /api/v2/auth/login` → `Ok.`
- unauthenticated `GET /api/v2/app/version` → HTTP 401
- `GET/PUT/PATCH/DELETE` on `pause`/`resume`/`stop`/`start` → HTTP 405 with `Allow: POST`

### Blocked / failing on fresh stack

- `GET /api/v2/torrents/info` and `?hashes=all` → **Unexpected Server Error**
- Root cause in container logs: `SyntaxError: Unexpected end of JSON input` while fetching aMule `api.php?get=shared|downloads|uploads`
- Observed aMule issues on clean volumes:
  - repeated `shareddir-recursive.dat` permission denied (`error 13`)
  - authenticated `api.php` calls often returned HTTP 200 with **empty body** instead of JSON (`[]`)
  - intermittent amuleweb/amuled restarts (`External connection closed`, `Unable to connect to amule`)

Because aMule-backed routes could not be validated end-to-end on this fresh stack, the following remain **unverified in this pass**:

- `hashes=all` / `ALL` / whitespace variants on live stack
- hash lookup via base32 / padded hex / internal hex against shared fixtures
- pause/resume metadata persistence across container restart
- LazyLibrarian synthetic magnet add + properties lookup on live stack
- PHP boundary harness over live `api.php`

**Status:** PR remains **draft**. Docker runtime validation is **not clean** yet on the 2026-06-19 fresh stack despite a successful image build.

## Historical LazyLibrarian E2E (older commits/images — not current HEAD proof)

Prior isolated-stack validation on commit `831adc1` (Hackable Magazine backissues) documented:

1. Torznab backissues search → synthetic base32 magnets in `NZBurl`
2. Wanted/Snatch → `POST /api/v2/torrents/add`
3. `GET /api/v2/torrents/properties?hash=<base32-btih>` → HTTP 200
4. LazyLibrarian row reached **Snatched**
5. Persistence across eMulerr container restart

That evidence supports the design direction but is **not** substituted for fresh validation at HEAD `441c41a`.

## Network note

Livebox/eD2K validation on the home network is separate from this API work: eD2k High ID was observed while KAD could remain firewalled without UDP global-search forwarding.

## Behavior notes

- **`POST /api/v2/torrents/add`:** `category` is optional and defaults to `""` (previously threw when absent). This matches LazyLibrarian, which does not always send a label on add.
- **State routes:** `pause`/`stop` and `resume`/`start` are aliases of the same handlers for qBittorrent 4.x/5.x naming compatibility.
- **`DELETE /api/v2/torrents/delete` with `deleteFiles=false`:** active downloads are cancelled in aMule; completed files stay on disk and remain in aMule's shared list while the qBittorrent-compatible API entry is hidden.

## Known protocol limitations

- Not universally qBittorrent- or BitTorrent-compatible
- Arbitrary `.torrent` uploads are rejected
- aMule has no real BitTorrent ratio; completed items expose compatibility ratio `1.0`

## Scope

Implements the API subset required by PyMedusa and by LazyLibrarian's eMulerr Torznab/synthetic-magnet workflow only.

## Readiness

**Not ready for review** until fresh Docker runtime validation passes with stable aMule JSON responses and the blocked checks above are green.
