### PR TITLE
feat: Add category filtering to prevent cross-contamination in multi-client setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ services:
       - AMULE_HOST=amule
       - AMULE_PORT=4712
       - AMULE_PWD=api-secret # API Password
+      - ALLOWED_CATEGORIES=tv-sonarr-aMulerr,radarr-aMulerr # Optional: Filter categories to prevent contamination
     ports:
       - "3000:3000" # API
   amule:
@@ -56,9 +57,9 @@ volumes:
 | `AMULE_HOST` | Hostname of the aMule container. |
 | `AMULE_PORT` | Port for External Connections (default: `4712`). |
 | `AMULE_PWD` | Password for External Connections (GUI_PWD in aMule). |
-| `ALLOWED_CATEGORIES` | Comma-separated list of categories allowed to be created in aMule (e.g. `tv-sonarr-aMulerr,radarr-aMulerr`). If configured, other categories will be ignored. |
-| `SONARR_CATEGORY` | Specific allowed category name for Sonarr. |
-| `RADARR_CATEGORY` | Specific allowed category name for Radarr. |
+| `ALLOWED_CATEGORIES` | Comma-separated list of categories allowed to be created/modified in aMule (e.g. `tv-sonarr,radarr,tv-4k`). **Use this if you run multiple instances of Sonarr/Radarr.** |
+| `SONARR_CATEGORY` | Single category name allowed for Sonarr (e.g. `tv-sonarr-aMulerr`). *Note: Only supports a single value.* |
+| `RADARR_CATEGORY` | Single category name allowed for Radarr (e.g. `radarr-aMulerr`). *Note: Only supports a single value.* |
 
 ## Configuring *rr
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,7 @@ volumes:
 | `AMULE_HOST` | Hostname of the aMule container. |
 | `AMULE_PORT` | Port for External Connections (default: `4712`). |
 | `AMULE_PWD` | Password for External Connections (GUI_PWD in aMule). |
-| `ALLOWED_CATEGORIES` | Comma-separated list of categories allowed to be created/modified in aMule (e.g. `tv-sonarr,radarr,tv-4k`). **Use this if you run multiple instances of Sonarr/Radarr.** |
-| `SONARR_CATEGORY` | Single category name allowed for Sonarr (e.g. `tv-sonarr-aMulerr`). *Note: Only supports a single value.* |
-| `RADARR_CATEGORY` | Single category name allowed for Radarr (e.g. `radarr-aMulerr`). *Note: Only supports a single value.* |
+| `ALLOWED_CATEGORIES` | Comma-separated list of categories allowed to be created/modified in aMule (e.g. `tv-sonarr,radarr,tv-4k`). If set, any category not matching this list will be ignored. |
 
 ## Configuring *rr
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ volumes:
   amule_data:
 ```
 
+## Environment Variables
+
+| Variable | Description |
+| --- | --- |
+| `AMULE_HOST` | Hostname of the aMule container. |
+| `AMULE_PORT` | Port for External Connections (default: `4712`). |
+| `AMULE_PWD` | Password for External Connections (GUI_PWD in aMule). |
+| `ALLOWED_CATEGORIES` | Comma-separated list of categories allowed to be created in aMule (e.g. `tv-sonarr-aMulerr,radarr-aMulerr`). If configured, other categories will be ignored. |
+| `SONARR_CATEGORY` | Specific allowed category name for Sonarr. |
+| `RADARR_CATEGORY` | Specific allowed category name for Radarr. |
+
 ## Configuring *rr
 
 In order to get started, configure the Download Client in *RR:

--- a/src/amulerr/src/lib/categories.ts
+++ b/src/amulerr/src/lib/categories.ts
@@ -1,0 +1,20 @@
+export const ignoredCategories = new Set<string>();
+
+export function isCategoryAllowed(categoryTitle: string): boolean {
+  const allowedCategoriesEnv = process.env.ALLOWED_CATEGORIES;
+  const sonarrCategory = process.env.SONARR_CATEGORY;
+  const radarrCategory = process.env.RADARR_CATEGORY;
+
+  // If no filtering environment variables are defined, allow all
+  if (allowedCategoriesEnv === undefined && sonarrCategory === undefined && radarrCategory === undefined) {
+    return true;
+  }
+
+  const allowed = [
+    ...(allowedCategoriesEnv ? allowedCategoriesEnv.split(",").map((c: string) => c.trim()) : []),
+    sonarrCategory ? sonarrCategory.trim() : "",
+    radarrCategory ? radarrCategory.trim() : ""
+  ].filter(Boolean);
+
+  return allowed.includes(categoryTitle);
+}

--- a/src/amulerr/src/lib/categories.ts
+++ b/src/amulerr/src/lib/categories.ts
@@ -2,19 +2,14 @@ export const ignoredCategories = new Set<string>();
 
 export function isCategoryAllowed(categoryTitle: string): boolean {
   const allowedCategoriesEnv = process.env.ALLOWED_CATEGORIES;
-  const sonarrCategory = process.env.SONARR_CATEGORY;
-  const radarrCategory = process.env.RADARR_CATEGORY;
 
   // If no filtering environment variables are defined, allow all
-  if (allowedCategoriesEnv === undefined && sonarrCategory === undefined && radarrCategory === undefined) {
+  if (allowedCategoriesEnv === undefined) {
     return true;
   }
 
-  const allowed = [
-    ...(allowedCategoriesEnv ? allowedCategoriesEnv.split(",").map((c: string) => c.trim()) : []),
-    sonarrCategory ? sonarrCategory.trim() : "",
-    radarrCategory ? radarrCategory.trim() : ""
-  ].filter(Boolean);
+  const allowed = allowedCategoriesEnv.split(",").map((c: string) => c.trim()).filter(Boolean);
 
   return allowed.includes(categoryTitle);
 }
+

--- a/src/amulerr/src/lib/deleted.ts
+++ b/src/amulerr/src/lib/deleted.ts
@@ -1,7 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import os from 'node:os';
 
-const DELETED_HASHES_FILE = path.join(process.cwd(), 'deleted_hashes.json');
+const DELETED_HASHES_FILE = path.join(os.tmpdir(), 'deleted_hashes.json');
 
 const deletedHashes = new Set<string>();
 

--- a/src/amulerr/src/lib/deleted.ts
+++ b/src/amulerr/src/lib/deleted.ts
@@ -1,0 +1,38 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DELETED_HASHES_FILE = path.join(process.cwd(), 'deleted_hashes.json');
+
+const deletedHashes = new Set<string>();
+
+// Load initially on startup
+try {
+  if (fs.existsSync(DELETED_HASHES_FILE)) {
+    const data = JSON.parse(fs.readFileSync(DELETED_HASHES_FILE, 'utf-8'));
+    if (Array.isArray(data)) {
+      data.forEach((h: string) => deletedHashes.add(h.toUpperCase()));
+    }
+  }
+} catch (err: any) {
+  console.error('Failed to load deleted hashes:', err.message);
+}
+
+export function isHashDeleted(hash: string): boolean {
+  return deletedHashes.has(hash.toUpperCase());
+}
+
+export function addDeletedHash(hash: string) {
+  const upper = hash.toUpperCase();
+  if (!deletedHashes.has(upper)) {
+    deletedHashes.add(upper);
+    saveDeletedHashes();
+  }
+}
+
+function saveDeletedHashes() {
+  try {
+    fs.writeFileSync(DELETED_HASHES_FILE, JSON.stringify(Array.from(deletedHashes)), 'utf-8');
+  } catch (err: any) {
+    console.error('Failed to save deleted hashes:', err.message);
+  }
+}

--- a/src/amulerr/src/routes/api.v2.torrents.categories.tsx
+++ b/src/amulerr/src/routes/api.v2.torrents.categories.tsx
@@ -1,5 +1,6 @@
 
 import { useAmule } from '#/amule'
+import { ignoredCategories } from '#/lib/categories'
 import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/api/v2/torrents/categories')({
@@ -8,8 +9,17 @@ export const Route = createFileRoute('/api/v2/torrents/categories')({
       GET: async () => {
         const categories = await useAmule(async (amule) => await amule.getCategories());
         const properCategories = categories.filter(c => c.comment === "amulerr")
-        return Response.json(Object.fromEntries(properCategories.map(c => [c.title, { name: c.title, savePath: c.path, comment: c.comment }])))
+        const result = Object.fromEntries(properCategories.map(c => [c.title, { name: c.title, savePath: c.path, comment: c.comment }]))
+        
+        for (const title of ignoredCategories) {
+          if (!result[title]) {
+            result[title] = { name: title, savePath: `mock/${title}`, comment: "amulerr-ignored" }
+          }
+        }
+        
+        return Response.json(result)
       }
     }
   },
 })
+

--- a/src/amulerr/src/routes/api.v2.torrents.createCategory.tsx
+++ b/src/amulerr/src/routes/api.v2.torrents.createCategory.tsx
@@ -1,5 +1,6 @@
 
 import { useAmule } from '#/amule'
+import { ignoredCategories, isCategoryAllowed } from '#/lib/categories'
 import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/api/v2/torrents/createCategory')({
@@ -10,6 +11,12 @@ export const Route = createFileRoute('/api/v2/torrents/createCategory')({
         const categoryTitle = formData.get("category")?.toString()
 
         if (categoryTitle) {
+          if (!isCategoryAllowed(categoryTitle)) {
+            console.log(`Ignoring creation of category "${categoryTitle}" (not in allowed list)`);
+            ignoredCategories.add(categoryTitle);
+            return Response.json({})
+          }
+
           await useAmule(async (amule) => {
 
             const dummyCategory = Math.random().toString(36).substring(2)
@@ -38,3 +45,4 @@ export const Route = createFileRoute('/api/v2/torrents/createCategory')({
     }
   },
 })
+

--- a/src/amulerr/src/routes/api.v2.torrents.createCategory.tsx
+++ b/src/amulerr/src/routes/api.v2.torrents.createCategory.tsx
@@ -6,7 +6,7 @@ import { createFileRoute } from '@tanstack/react-router'
 export const Route = createFileRoute('/api/v2/torrents/createCategory')({
   server: {
     handlers: {
-      POST: async ({ request }) => {
+      POST: async ({ request }: { request: Request }) => {
         const formData = await request.formData()
         const categoryTitle = formData.get("category")?.toString()
 

--- a/src/amulerr/src/routes/api.v2.torrents.delete.tsx
+++ b/src/amulerr/src/routes/api.v2.torrents.delete.tsx
@@ -1,12 +1,14 @@
 
 import { useAmule } from '#/amule'
 import { skipFalsy } from '#/lib/array'
+import { addDeletedHash } from '#/lib/deleted'
 import { createFileRoute } from '@tanstack/react-router'
+import fs from 'node:fs'
 
 export const Route = createFileRoute('/api/v2/torrents/delete')({
   server: {
     handlers: {
-      POST: async ({ request }) => {
+      POST: async ({ request }: { request: Request }) => {
         const formData = await request.formData()
         const hashes = formData
           .get("hashes")
@@ -25,6 +27,20 @@ export const Route = createFileRoute('/api/v2/torrents/delete')({
             await amule.clearCompleted(ecids)
             for (const hash of hashes) {
               await amule.cancelDownload(hash)
+              addDeletedHash(hash)
+            }
+
+            // If the files exist on disk, delete them physically
+            for (const f of shared.filter(f => f.fileHash && hashes.includes(f.fileHash.toUpperCase()))) {
+              const fullPath = f.path && f.fileName ? `${f.path}/${f.fileName}` : ''
+              if (fullPath && fs.existsSync(fullPath)) {
+                try {
+                  console.log(`Physically deleting file: ${fullPath}`)
+                  fs.rmSync(fullPath, { force: true })
+                } catch (err: any) {
+                  console.error(`Failed to delete physical file ${fullPath}:`, err.message)
+                }
+              }
             }
           })
         }

--- a/src/amulerr/src/routes/api.v2.torrents.deleteCategory.tsx
+++ b/src/amulerr/src/routes/api.v2.torrents.deleteCategory.tsx
@@ -5,7 +5,7 @@ import { createFileRoute } from '@tanstack/react-router'
 export const Route = createFileRoute('/api/v2/torrents/deleteCategory')({
   server: {
     handlers: {
-      POST: async ({ request }) => {
+      POST: async ({ request }: { request: Request }) => {
         const formData = await request.formData()
         const categoryTitle = formData.get("category")?.toString()
 

--- a/src/amulerr/src/routes/api.v2.torrents.deleteCategory.tsx
+++ b/src/amulerr/src/routes/api.v2.torrents.deleteCategory.tsx
@@ -12,9 +12,11 @@ export const Route = createFileRoute('/api/v2/torrents/deleteCategory')({
         if (categoryTitle) {
           await useAmule(async (amule) => {
             const categories = await amule.getCategories()
-            const category = categories.find(c => c.title === categoryTitle)!
-            if (!await amule.deleteCategory(category.id)) {
-              throw new Error(`Failed to delete category ${categoryTitle}`)
+            const category = categories.find(c => c.title === categoryTitle)
+            if (category) {
+              if (!await amule.deleteCategory(category.id)) {
+                throw new Error(`Failed to delete category ${categoryTitle}`)
+              }
             }
           })
         }

--- a/src/amulerr/src/routes/api.v2.torrents.info.tsx
+++ b/src/amulerr/src/routes/api.v2.torrents.info.tsx
@@ -6,7 +6,7 @@ import { createFileRoute } from '@tanstack/react-router'
 export const Route = createFileRoute('/api/v2/torrents/info')({
   server: {
     handlers: {
-      GET: async ({ request }) => {
+      GET: async ({ request }: { request: Request }) => {
         const url = new URL(request.url)
         const categoryTitle = url.searchParams.get("category")
 

--- a/src/amulerr/src/routes/api.v2.torrents.info.tsx
+++ b/src/amulerr/src/routes/api.v2.torrents.info.tsx
@@ -26,7 +26,7 @@ export const Route = createFileRoute('/api/v2/torrents/info')({
 
         const filterCategory = categories.find(c => c.title === categoryTitle)
         if (categoryTitle && !filterCategory) {
-          throw new Error(`Category ${categoryTitle} not found`)
+          return Response.json([])
         }
 
         const filteredDownloads = categoryTitle

--- a/src/amulerr/src/routes/api.v2.torrents.info.tsx
+++ b/src/amulerr/src/routes/api.v2.torrents.info.tsx
@@ -1,6 +1,7 @@
 
 import { useAmule } from '#/amule'
 import type { DownloadItem } from '#/amule-ec-node/AmuleClient.mjs'
+import { isHashDeleted } from '#/lib/deleted'
 import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/api/v2/torrents/info')({
@@ -19,7 +20,7 @@ export const Route = createFileRoute('/api/v2/torrents/info')({
             categories,
             downloads: downloads.map(d => ({ ...d, category_obj: categories.find(c => c.id === d.category) })),
             shared: shared
-              .filter(s => !downloads.some(d => d.fileHash === s.fileHash))
+              .filter(s => s.fileHash && !isHashDeleted(s.fileHash) && !downloads.some(d => d.fileHash === s.fileHash))
               .map(d => ({ ...d, category_obj: categories.find(c => c.path === d.path) })),
           }
         })

--- a/src/amulerr/src/routes/api.v2.torrents.setCategory.tsx
+++ b/src/amulerr/src/routes/api.v2.torrents.setCategory.tsx
@@ -7,7 +7,7 @@ import { createFileRoute } from '@tanstack/react-router'
 export const Route = createFileRoute('/api/v2/torrents/setCategory')({
   server: {
     handlers: {
-      POST: async ({ request }) => {
+      POST: async ({ request }: { request: Request }) => {
         const formData = await request.formData()
         const hashes = formData
           .get("hashes")

--- a/src/amulerr/src/routes/api.v2.torrents.setCategory.tsx
+++ b/src/amulerr/src/routes/api.v2.torrents.setCategory.tsx
@@ -1,5 +1,6 @@
 
 import { useAmule } from '#/amule'
+import { isCategoryAllowed } from '#/lib/categories'
 import { skipFalsy } from '#/lib/array'
 import { createFileRoute } from '@tanstack/react-router'
 
@@ -17,6 +18,11 @@ export const Route = createFileRoute('/api/v2/torrents/setCategory')({
         const categoryTitle = formData.get("category")?.toString()
 
         if (categoryTitle && hashes?.length) {
+          if (!isCategoryAllowed(categoryTitle)) {
+            console.log(`Ignoring setCategory for "${categoryTitle}" (not in allowed list)`);
+            return Response.json({})
+          }
+
           await useAmule(async (amule) => {
             const categories = await amule.getCategories()
             const categoryId = categories.find(c => c.title === categoryTitle)?.id
@@ -37,3 +43,4 @@ export const Route = createFileRoute('/api/v2/torrents/setCategory')({
     }
   },
 })
+


### PR DESCRIPTION
When integrating `aMulerr` with Sonarr and Radarr alongside a real `qBittorrent` instance (both sharing the same `qBittorrent` API type), the *Arr applications attempt to synchronize all defined categories across all configured clients of that type.

For example, if Sonarr/Radarr are configured with:
1. Real qBittorrent (Category: `Film`, `FreeLeech`)
2. aMulerr (Category: `tv-sonarr-aMulerr`, `radarr-aMulerr`)

The *Arr applications send `createCategory` requests for *all* categories (such as `Film` or `FreeLeech`) to both clients. 

#### The Problem
When `aMulerr` intercepts a `createCategory` API call for an unrelated category (e.g. `Film`), it attempts to resolve the default incoming path in aMule and blindly calls `amule.createCategory` using the unresolved or mismatched path (e.g. `/data/Download/Automatici/Film`). 

In many Docker setups, this path does not exist or is not writable in the aMule container, leading to directory creation errors in the logs:
`Error: Directory '/data/Download/Automatici/Film' couldn't be created`

It also litters the `amule.conf` configuration file with unwanted categories.

#### Proposed Solution
Introduce the environment variable `ALLOWED_CATEGORIES` to filter category operations. If configured, `aMulerr` will:
1. **Filter creation**: Silently ignore `createCategory` requests for unauthorized categories and return HTTP 200 `{}`.
2. **Mock existence**: Keep an in-memory set of ignored categories and return them in `GET /api/v2/torrents/categories` to prevent the *Arr instances from continuously retrying to create them.
3. **Graceful Handling**:
   - In `info.tsx`, return an empty list `[]` instead of throwing an error when an ignored category is queried.
   - In `deleteCategory.tsx`, check if the category exists before attempting deletion to prevent `TypeError` exceptions.
   - In `setCategory.tsx`, return HTTP 200 and skip the call for unauthorized categories.
