### PR TITLE
feat: improve qBittorrent compatibility for *arr, Medusa and LazyLibrarian

### DIFF
--- a/src/amulerr/COMPATIBILITY.md
+++ b/src/amulerr/COMPATIBILITY.md
@@ -1,0 +1,110 @@
+# qBittorrent API compatibility
+
+Verified against upstream client source (July 2026).
+
+## Sonarr (`QBittorrentProxyV2.cs`)
+
+| Endpoint                                                    | Status                                                       |
+| ----------------------------------------------------------- | ------------------------------------------------------------ |
+| `GET /api/v2/app/webapiVersion`                             | Implemented (`text/plain`, `2.11.0`)                         |
+| `GET /api/v2/app/version`                                   | Implemented (`text/plain`, `v4.6.7`)                         |
+| `GET /api/v2/app/preferences`                               | Implemented (ratio/seeding limits disabled)                  |
+| `POST /api/v2/auth/login`                                   | Implemented (`Ok.` + `SID` cookie)                           |
+| `GET /api/v2/torrents/info`                                 | Implemented (+ `ratio`, `seeding_time`, `completion_on`, …)  |
+| `GET /api/v2/torrents/properties`                           | Implemented — **404 when missing** (fixes `IsTorrentLoaded`) |
+| `GET /api/v2/torrents/files`                                | Implemented                                                  |
+| `POST /api/v2/torrents/add`                                 | Implemented — **category required** (see below)              |
+| `POST /api/v2/torrents/delete`                              | Implemented (`hashes=all` clears shared)                     |
+| `POST /api/v2/torrents/setCategory`                         | Implemented                                                  |
+| `POST /api/v2/torrents/createCategory`                      | Implemented                                                  |
+| `GET /api/v2/torrents/categories`                           | Implemented                                                  |
+| `POST /api/v2/torrents/setShareLimits`                      | No-op `Ok`                                                   |
+| `POST /api/v2/torrents/topPrio`                             | No-op `Ok`                                                   |
+| `POST /api/v2/torrents/setForceStart`                       | No-op `Ok`                                                   |
+| `POST /api/v2/torrents/contents`                            | Covered (Medusa alias → same as `/torrents/files`)           |
+| `POST /api/v2/torrents/pause` / `resume` / `start` / `stop` | Implemented                                                  |
+
+## Radarr
+
+Same proxy as Sonarr (`QBittorrentProxyV2.cs`); same coverage.
+
+## PyMedusa (`medusa/clients/torrent/qbittorrent.py`)
+
+| Need                                                                                                | Status                                                               |
+| --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `webapiVersion` + `auth/login`                                                                      | Covered                                                              |
+| `torrents/add` with `urls`, `category`, `savepath`                                                  | Covered — **category required**; `savepath` ignored                  |
+| `torrents/info` fields: `hash`, `state`, `ratio`, `downloaded`, `size`, `save_path`, `content_path` | Covered                                                              |
+| `torrents/setCategory`, `torrents/delete`                                                           | Covered                                                              |
+| `torrents/pause` / `resume` / `stop` / `start`                                                      | Covered via existing routes                                          |
+| `POST /api/v2/torrents/contents`                                                                    | Covered — alias of `/torrents/files` (PyMedusa seeding/post-process) |
+| `GET /api/v2/torrents/categories`                                                                   | Already covered                                                      |
+| `POST /api/v2/torrents/createCategory`                                                              | Already covered                                                      |
+
+## LazyLibrarian GitLab (`lib/qbittorrent.py` + `lazylibrarian/qbittorrent.py`)
+
+| Method                                      | qBittorrent API                 | Status                                                     |
+| ------------------------------------------- | ------------------------------- | ---------------------------------------------------------- |
+| `api_version`                               | `GET app/webapiVersion`         | Covered                                                    |
+| `qbittorrent_version`                       | `GET app/version`               | Covered                                                    |
+| `preferences()`                             | `GET app/preferences`           | Covered (`max_ratio_*`, `max_seeding_time_*`)              |
+| `torrents(category=…)`                      | `GET torrents/info`             | Covered — unknown category returns `[]`                    |
+| `get_torrent(hash)`                         | `GET torrents/properties`       | Covered — 404 while polling after add                      |
+| `get_torrent_files(hash)`                   | `GET torrents/files`            | Covered                                                    |
+| `download_from_link` / `download_from_file` | `POST torrents/add`             | Covered — **category must be configured** in LazyLibrarian |
+| `delete` / `delete_permanently`             | `POST torrents/delete`          | Covered                                                    |
+| `pause`                                     | `POST torrents/pause` or `stop` | Covered                                                    |
+
+## Hash / magnet rules
+
+Centralized in `src/lib/links.tsx` and `src/lib/torrents.ts`:
+
+- Internal ed2k: exactly **32 hex**, uppercase (`normalizeEd2kHash`).
+- API-facing btih: exactly **40 hex** lowercase, trailing **`00000000`** (`toQbittorrentHashStrict`).
+- Genuine non-padded BitTorrent 40-hex hashes are **rejected**.
+- Malformed or too-long hashes are **rejected** (no silent slicing).
+- All route hash comparisons use `sameEd2kHash()` / normalized sets.
+- `fromMagnetLink` only accepts aMulerr magnets with **exact** `tr=http://amulerr` (prefix matches like `http://amulerr.evil` rejected).
+- Trailing magnet parameters after `tr=http://amulerr` are accepted.
+- Invalid hashes rejected before aMule RPC.
+
+## `/torrents/add` behavior
+
+- `urls` (amulerr magnet) and `category` are **required**.
+- Missing/blank `urls` or `category` → **400** plain text (not an unhandled server error).
+- Unknown category → **404** plain text.
+- Invalid magnet → **400** plain text.
+- Duplicate add is **idempotent** (200 + `{}` if hash already in queue/shared).
+- aMule requires a category ID; there is no safe default category.
+
+## `/torrents/info` category filter
+
+- `GET /torrents/info?category=unknown` returns **`[]`**, not a server error.
+- Avoids \*arr client crashes when polling categories aMulerr does not own.
+
+## `/torrents/properties` behavior note
+
+Sonarr/Radarr `IsTorrentLoaded()` returns true on any HTTP 200 from `/torrents/properties`, so missing torrents **must** be 404. LazyLibrarian treats 404 as retry/failure in its add poll loop (`get_torrent` → falsy).
+
+## JSON response stability
+
+- Strings default to `""`; numbers use `0` or `-1` only when semantically intended.
+- `progress` is always **0..1**; `amount_left` and `eta` are never negative.
+- `/torrents/files` and `/torrents/contents` return **404 + `[]`** for missing/invalid hashes.
+
+## Harmless unsupported qBittorrent features (no-op or ignored)
+
+- Per-torrent share limits (`setShareLimits`)
+- Queue priority (`topPrio`)
+- Force start flag (`setForceStart`)
+- `savepath` on add (category path from aMule categories)
+- `paused` / `stopped` / `ratioLimit` / `sequentialDownload` on add
+
+## Runtime validation
+
+Docker runtime validation with aMule + aMulerr + LazyLibrarian + PyMedusa/Medusa is **still required** before merge upstream.
+
+## Out of scope
+
+- Real BitTorrent magnets (aMulerr magnets only, `tr=http://amulerr`)
+- Arbitrary tracker URLs

--- a/src/amulerr/package.json
+++ b/src/amulerr/package.json
@@ -10,7 +10,7 @@
     "generate-routes": "tsr generate",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run",
+    "test": "vitest run --config vitest.config.ts",
     "lint": "eslint",
     "format": "prettier --write . && eslint --fix",
     "check": "prettier --check ."
@@ -24,7 +24,6 @@
     "@tanstack/react-start": "latest",
     "@tanstack/router-plugin": "^1.132.0",
     "async-mutex": "^0.5.0",
-    "hi-base32": "^0.5.1",
     "html-entities": "^2.6.0",
     "lucide-react": "^0.545.0",
     "nitro": "npm:nitro-nightly@latest",

--- a/src/amulerr/pnpm-lock.yaml
+++ b/src/amulerr/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       async-mutex:
         specifier: ^0.5.0
         version: 0.5.0
-      hi-base32:
-        specifier: ^0.5.1
-        version: 0.5.1
       html-entities:
         specifier: ^2.6.0
         version: 2.6.0
@@ -1816,9 +1813,6 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-
-  hi-base32@0.5.1:
-    resolution: {integrity: sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA==}
 
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
@@ -4255,8 +4249,6 @@ snapshots:
       crossws: 0.4.6(srvx@0.11.16)
 
   has-flag@4.0.0: {}
-
-  hi-base32@0.5.1: {}
 
   hookable@6.1.1: {}
 

--- a/src/amulerr/src/lib/cookies.ts
+++ b/src/amulerr/src/lib/cookies.ts
@@ -1,0 +1,15 @@
+export function isSecureRequest(request: Request) {
+  if (new URL(request.url).protocol === 'https:') {
+    return true
+  }
+  const forwarded = request.headers
+    .get('x-forwarded-proto')
+    ?.split(',')[0]
+    ?.trim()
+    .toLowerCase()
+  return forwarded === 'https'
+}
+
+export function secureCookieSuffix(request: Request) {
+  return isSecureRequest(request) ? '; Secure' : ''
+}

--- a/src/amulerr/src/lib/indexer.test.ts
+++ b/src/amulerr/src/lib/indexer.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { itemsResponse } from './indexer'
+
+const ED2K = 'A1B2C3D4E5F60718293A4B5C6D7E8F90'
+
+describe('itemsResponse', () => {
+  it('skips search results with invalid hashes instead of failing the feed', () => {
+    const xml = itemsResponse(
+      [
+        { fileName: 'good.pdf', fileHash: ED2K, fileSize: 100, sourceCount: 3 },
+        {
+          fileName: 'bad.pdf',
+          fileHash: 'not-a-hash',
+          fileSize: 50,
+          sourceCount: 1,
+        },
+      ],
+      [7000],
+    )
+
+    expect(xml).toContain('total="1"')
+    expect(xml).toContain('good.pdf')
+    expect(xml).not.toContain('bad.pdf')
+  })
+})

--- a/src/amulerr/src/lib/indexer.ts
+++ b/src/amulerr/src/lib/indexer.ts
@@ -1,12 +1,12 @@
-import { skipFalsy } from "./array"
-import { encode } from "html-entities"
-import { buildRFC822Date } from "./time"
-import type { searchAll } from "#/amule"
-import { toMagnetLink } from "./links"
+import { skipFalsy } from './array'
+import { encode } from 'html-entities'
+import { buildRFC822Date } from './time'
+import type { searchAll } from '#/amule'
+import { toMagnetLink } from './links'
 
 export const fakeItem = {
-  fileName: "FAKE",
-  fileHash: "00000000000000000000000000000000",
+  fileName: 'FAKE',
+  fileHash: '00000000000000000000000000000000',
   fileSize: 1,
   sourceCount: 1,
 } satisfies Awaited<ReturnType<typeof searchAll>>[number]
@@ -20,63 +20,78 @@ export const emptyResponse = (offset: string) => `
 
 export const itemsResponse = (
   searchResults: Awaited<ReturnType<typeof searchAll>>,
-  categories: number[]
-) => `
-  <rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
-    <channel>
-      <torznab:response offset="0" total="${searchResults.length}"/>
-      ${searchResults.map(
-  (item) => `
+  categories: number[],
+) => {
+  const items = searchResults.flatMap((item) => {
+    let magnet: string
+    try {
+      magnet = toMagnetLink(item.fileHash, item.fileName, item.fileSize)
+    } catch {
+      return []
+    }
+
+    return [
+      `
           <item>
             <title>${encode(item.fileName)}</title>
             <guid>${item.fileHash}-${encode(item.fileName)}</guid>
+            <link>${encode(magnet)}</link>
             <pubDate>${buildRFC822Date(new Date())}</pubDate>
-            <enclosure url="${encode(toMagnetLink(item.fileHash, item.fileName, item.fileSize))}" length="${item.fileSize}" type="application/x-bittorrent" />
+            <enclosure url="${encode(magnet)}" length="${item.fileSize}" type="application/x-bittorrent" />
             <torznab:attr name="size" value="${item.fileSize}" />
-            ${categories.map((c) => `<torznab:attr name="category" value="${c}" />`).join("")}
+            <torznab:attr name="magneturl" value="${encode(magnet)}" />
+            ${categories.map((c) => `<torznab:attr name="category" value="${c}" />`).join('')}
             <torznab:attr name="seeders" value="${item.sourceCount}" />
             <torznab:attr name="downloadvolumefactor" value="0" />
             <torznab:attr name="uploadvolumefactor" value="0" />
             <torznab:attr name="minimumratio" value="0" />
             <torznab:attr name="minimumseedtime" value="0" />
             <torznab:attr name="tag" value="freeleech" />
-          </item>`
-)}
+          </item>`,
+    ]
+  })
+
+  return `
+  <rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+    <channel>
+      <torznab:response offset="0" total="${items.length}"/>
+      ${items.join('')}
     </channel>
   </rss>
   `
+}
 
 export function group<T>(
   arr: T[],
-  operator: "AND" | "OR",
-  parenthesis: boolean
+  operator: 'AND' | 'OR',
+  parenthesis: boolean,
 ) {
   arr = arr.filter(skipFalsy)
 
   const joined =
-    operator === "OR"
+    operator === 'OR'
       ? arr.join(` ${operator} `)
       : arr
-        .sort(
-          // move parenthesis to the end
-          (a, b) =>
-            (typeof a === "string" && a.startsWith("(") ? 1 : 0) -
-            (typeof b === "string" && b.startsWith("(") ? 1 : 0)
-        )
-        .reduce(
-          (prev, curr) =>
-            prev === ""
-              ? `${curr}`
-              : prev.endsWith(")") ||
-                (typeof curr === "string" && curr.startsWith("("))
-                ? `${prev} AND ${curr}`
-                : `${prev} ${curr}`,
-          ""
-        )
+          .sort(
+            // move parenthesis to the end
+            (a, b) =>
+              (typeof a === 'string' && a.startsWith('(') ? 1 : 0) -
+              (typeof b === 'string' && b.startsWith('(') ? 1 : 0),
+          )
+          .reduce(
+            (prev, curr) =>
+              prev === ''
+                ? `${curr}`
+                : prev.endsWith(')') ||
+                    (typeof curr === 'string' && curr.startsWith('('))
+                  ? `${prev} AND ${curr}`
+                  : `${prev} ${curr}`,
+            '',
+          )
 
   if (!parenthesis) {
     return joined
   }
 
-  return arr.length > 1 ? `(${joined})` : `${arr[0] ?? ""}`
+  return arr.length > 1 ? `(${joined})` : `${arr[0] ?? ''}`
 }

--- a/src/amulerr/src/lib/links.test.ts
+++ b/src/amulerr/src/lib/links.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest'
+import {
+  fromEd2kLink,
+  fromMagnetLink,
+  fromQbittorrentHashStrict,
+  isAmulerrBtih,
+  isValidEd2kHash,
+  normalizeEd2kHash,
+  sameEd2kHash,
+  toEd2kLink,
+  toMagnetLink,
+  toQbittorrentHash,
+  toQbittorrentHashStrict,
+} from './links'
+
+const ED2K = 'A1B2C3D4E5F60718293A4B5C6D7E8F90'
+const BTIH = toQbittorrentHashStrict(ED2K)!
+
+describe('hash helpers', () => {
+  it('validates exact 32-hex ed2k hashes', () => {
+    expect(isValidEd2kHash(ED2K)).toBe(true)
+    expect(isValidEd2kHash(`${ED2K}00`)).toBe(false)
+    expect(isValidEd2kHash('not-a-hash')).toBe(false)
+  })
+
+  it('normalizes 32-hex and padded 40-hex btih', () => {
+    expect(normalizeEd2kHash(ED2K)).toBe(ED2K)
+    expect(normalizeEd2kHash(ED2K.toLowerCase())).toBe(ED2K)
+    expect(normalizeEd2kHash(BTIH)).toBe(ED2K)
+  })
+
+  it('rejects real non-padded BitTorrent btih and malformed hashes', () => {
+    expect(normalizeEd2kHash('b'.repeat(40))).toBeNull()
+    expect(normalizeEd2kHash(`${ED2K}garbage`)).toBeNull()
+    expect(normalizeEd2kHash('')).toBeNull()
+  })
+
+  it('maps ed2k to strict qBittorrent btih', () => {
+    expect(toQbittorrentHashStrict(ED2K)).toBe(`${ED2K.toLowerCase()}00000000`)
+    expect(toQbittorrentHashStrict('bad')).toBeNull()
+    expect(toQbittorrentHash(ED2K)).toBe(`${ED2K.toLowerCase()}00000000`)
+  })
+
+  it('maps strict qBittorrent btih back to ed2k', () => {
+    expect(fromQbittorrentHashStrict(BTIH)).toBe(ED2K)
+    expect(fromQbittorrentHashStrict('a'.repeat(40))).toBeNull()
+  })
+
+  it('compares ed2k hashes case-insensitively', () => {
+    expect(sameEd2kHash(ED2K, ED2K.toLowerCase())).toBe(true)
+    expect(sameEd2kHash(ED2K, BTIH)).toBe(true)
+    expect(sameEd2kHash(ED2K, 'B'.repeat(32))).toBe(false)
+  })
+
+  it('recognizes amulerr padded btih', () => {
+    expect(isAmulerrBtih(BTIH)).toBe(true)
+    expect(isAmulerrBtih('a'.repeat(40))).toBe(false)
+  })
+})
+
+describe('fromMagnetLink', () => {
+  const magnet = toMagnetLink(ED2K, 'Test Book', 12345)
+
+  it('parses amulerr-generated magnets', () => {
+    expect(fromMagnetLink(magnet)).toEqual({
+      hash: ED2K,
+      name: 'Test Book',
+      size: 12345,
+    })
+  })
+
+  it('rejects non-magnet protocols', () => {
+    expect(() => fromMagnetLink('http://example.com')).toThrow(
+      'Invalid magnet link',
+    )
+  })
+
+  it('rejects random non-amulerr 40-hex btih', () => {
+    const fake = magnet.replace(BTIH, 'b'.repeat(40))
+    expect(() => fromMagnetLink(fake)).toThrow('Invalid magnet link')
+  })
+
+  it('accepts filenames containing a literal percent sign', () => {
+    const percentName = '50% Off.mkv'
+    const withPercent = toMagnetLink(ED2K, percentName, 12345)
+    expect(fromMagnetLink(withPercent)).toEqual({
+      hash: ED2K,
+      name: percentName,
+      size: 12345,
+    })
+  })
+
+  it('rejects invalid size', () => {
+    const bad = magnet.replace('xl=12345', 'xl=12abc')
+    expect(() => fromMagnetLink(bad)).toThrow('Invalid magnet link')
+  })
+
+  it('rejects extra tracker parameters before xl', () => {
+    const withExtra = magnet.replace(
+      `&xl=12345`,
+      `&tr=http%3A%2F%2Ftracker&xl=12345`,
+    )
+    expect(() => fromMagnetLink(withExtra)).toThrow('Invalid magnet link')
+  })
+
+  it('accepts trailing parameters after tr=http://amulerr', () => {
+    const withTrailing = `${magnet}&foo=bar`
+    expect(fromMagnetLink(withTrailing)).toEqual({
+      hash: ED2K,
+      name: 'Test Book',
+      size: 12345,
+    })
+  })
+
+  it('rejects trackers that only prefix-match http://amulerr', () => {
+    const evilTracker = magnet.replace(
+      '&tr=http://amulerr',
+      '&tr=http://amulerr.evil',
+    )
+    expect(() => fromMagnetLink(evilTracker)).toThrow('Invalid magnet link')
+  })
+})
+
+describe('fromEd2kLink', () => {
+  const ed2k = toEd2kLink(ED2K, 'Test Book', 12345)
+
+  it('parses strict ed2k links', () => {
+    expect(fromEd2kLink(ed2k)).toEqual({
+      hash: ED2K,
+      name: 'Test Book',
+      size: 12345,
+    })
+  })
+
+  it('rejects invalid hash length', () => {
+    expect(() =>
+      fromEd2kLink(`ed2k://|file|book.pdf|100|${'a'.repeat(31)}|/`),
+    ).toThrow('Invalid ed2k link')
+  })
+
+  it('rejects non-numeric size', () => {
+    expect(() => fromEd2kLink(`ed2k://|file|book.pdf|12abc|${ED2K}|/`)).toThrow(
+      'Invalid ed2k link',
+    )
+  })
+
+  it('rejects malformed percent-encoding in name', () => {
+    expect(() => fromEd2kLink(`ed2k://|file|%E0%A4%A|100|${ED2K}|/`)).toThrow(
+      'Invalid ed2k link',
+    )
+  })
+})

--- a/src/amulerr/src/lib/links.tsx
+++ b/src/amulerr/src/lib/links.tsx
@@ -1,47 +1,165 @@
-import base32 from "hi-base32"
+const ED2K_HASH_RE = /^[0-9A-F]{32}$/
+const AMULERR_BTIH_RE = /^[0-9a-f]{40}$/
+
+export function isValidEd2kHash(value: string): boolean {
+  const trimmed = value.trim()
+  if (trimmed.length !== 32) {
+    return false
+  }
+  return ED2K_HASH_RE.test(trimmed.toUpperCase())
+}
+
+export function isAmulerrBtih(value: string): boolean {
+  const normalized = value.trim().toLowerCase()
+  return AMULERR_BTIH_RE.test(normalized) && normalized.endsWith('00000000')
+}
+
+/** Internal ed2k hash: exactly 32 hex, uppercase. Accepts 32-hex or padded 40-hex aMulerr btih input. */
+export function normalizeEd2kHash(
+  value: string | null | undefined,
+): string | null {
+  if (!value?.trim()) {
+    return null
+  }
+
+  const trimmed = value.trim()
+
+  if (trimmed.length === 32 && /^[0-9a-fA-F]{32}$/.test(trimmed)) {
+    return trimmed.toUpperCase()
+  }
+
+  if (trimmed.length === 40 && /^[0-9a-fA-F]{40}$/.test(trimmed)) {
+    if (!isAmulerrBtih(trimmed)) {
+      return null
+    }
+    return fromQbittorrentHashStrict(trimmed)
+  }
+
+  return null
+}
+
+export function sameEd2kHash(
+  a: string | null | undefined,
+  b: string | null | undefined,
+): boolean {
+  const left = normalizeEd2kHash(a)
+  const right = normalizeEd2kHash(b)
+  return left !== null && right !== null && left === right
+}
+
+/** API qBittorrent hash: exactly 40 hex lowercase with trailing 00000000. */
+export function toQbittorrentHashStrict(ed2kHash: string): string | null {
+  const normalized = normalizeEd2kHash(ed2kHash)
+  if (!normalized) {
+    return null
+  }
+  return `${normalized.toLowerCase()}00000000`
+}
+
+export function fromQbittorrentHashStrict(
+  qbittorrentHash: string,
+): string | null {
+  const trimmed = qbittorrentHash.trim()
+  if (trimmed.length !== 40 || !/^[0-9a-fA-F]{40}$/.test(trimmed)) {
+    return null
+  }
+  if (!isAmulerrBtih(trimmed)) {
+    return null
+  }
+  const ed2k = trimmed.slice(0, 32).toUpperCase()
+  return isValidEd2kHash(ed2k) ? ed2k : null
+}
+
+/** Stable API output for a known ed2k hash; returns "" when invalid. */
+export function toQbittorrentHash(ed2kHash: string): string {
+  return toQbittorrentHashStrict(ed2kHash) ?? ''
+}
 
 export function toMagnetLink(hash: string, name: string, size: number) {
-  const hashBuffer = Buffer.from(hash, "hex")
-  const base32Buffer = Buffer.alloc(20, "\0")
-  hashBuffer.copy(base32Buffer)
-  const base32Hash = base32.encode(base32Buffer).toUpperCase()
+  const btih = toQbittorrentHashStrict(hash)
+  if (!btih) {
+    throw new Error('Invalid ed2k hash')
+  }
 
-  return `magnet:?xt=urn:btih:${base32Hash}&dn=${encodeURIComponent(name)}&xl=${size}&tr=http://amulerr`
+  return `magnet:?xt=urn:btih:${btih}&dn=${encodeURIComponent(name)}&xl=${size}&tr=http://amulerr`
 }
 
 export function fromMagnetLink(magnetLink: string) {
-  const extractMagnetLinkInfo =
-    /magnet:\?xt=urn:btih:(?<hash>.*)&dn=(?<name>.*)&xl=(?<size>[^&]+)&tr=http:\/\/amulerr/
-  const {
-    hash: base32Hash,
-    name,
-    size,
-  } = extractMagnetLinkInfo.exec(magnetLink)?.groups ?? {}
-
-  if (!base32Hash || !name || !size) {
-    throw new Error("Invalid magnet link")
+  if (!magnetLink.startsWith('magnet:?')) {
+    throw new Error('Invalid magnet link')
   }
 
-  const hash = Buffer.from(base32.decode.asBytes(base32Hash))
-    .toString("hex")
-    .substring(0, 32)
-    .toUpperCase()
-  return { hash, name: decodeURIComponent(name), size: parseInt(size) }
+  const params = new URLSearchParams(magnetLink.slice('magnet:?'.length))
+  const xt = params.get('xt')
+  if (!xt?.startsWith('urn:btih:')) {
+    throw new Error('Invalid magnet link')
+  }
+
+  const btih = xt.slice('urn:btih:'.length)
+  const name = params.get('dn')
+  const size = params.get('xl')
+  const tracker = params.get('tr')
+
+  if (!btih || !name || !size || tracker !== 'http://amulerr') {
+    throw new Error('Invalid magnet link')
+  }
+
+  if (!isAmulerrBtih(btih)) {
+    throw new Error('Invalid magnet link')
+  }
+
+  const hash = fromQbittorrentHashStrict(btih)
+  if (!hash) {
+    throw new Error('Invalid magnet link')
+  }
+
+  if (!/^\d+$/.test(size)) {
+    throw new Error('Invalid magnet link')
+  }
+
+  const parsedSize = Number(size)
+  if (!Number.isSafeInteger(parsedSize) || String(parsedSize) !== size) {
+    throw new Error('Invalid magnet link')
+  }
+
+  return { hash, name, size: parsedSize }
 }
 
 export function toEd2kLink(hash: string, name: string, size: number) {
-  return `ed2k://|file|${name}|${size}|${hash}|/`
+  const normalized = normalizeEd2kHash(hash)
+  if (!normalized) {
+    throw new Error('Invalid ed2k hash')
+  }
+  return `ed2k://|file|${name}|${size}|${normalized}|/`
 }
 
 export function fromEd2kLink(ed2kLink: string) {
-  const extractEd2kLinkInfo =
-    /ed2k:\/\/\|file\|(?<name>[^\|]+)\|(?<size>[^\|]+)\|(?<hash>[^\|]+)\|/
+  const match =
+    /^ed2k:\/\/\|file\|(?<name>[^|]+)\|(?<size>\d+)\|(?<hash>[0-9a-fA-F]{32})\|\/?$/.exec(
+      ed2kLink,
+    )
 
-  const { hash, name, size } = extractEd2kLinkInfo.exec(ed2kLink)?.groups ?? {}
-
+  const { hash, name, size } = match?.groups ?? {}
   if (!hash || !name || !size) {
-    throw new Error("Invalid ed2k link")
+    throw new Error('Invalid ed2k link')
   }
 
-  return { hash, name: decodeURIComponent(name), size: parseInt(size) }
+  const normalizedHash = normalizeEd2kHash(hash)
+  if (!normalizedHash) {
+    throw new Error('Invalid ed2k link')
+  }
+
+  const parsedSize = Number(size)
+  if (!Number.isSafeInteger(parsedSize) || String(parsedSize) !== size) {
+    throw new Error('Invalid ed2k link')
+  }
+
+  let decodedName: string
+  try {
+    decodedName = decodeURIComponent(name)
+  } catch {
+    throw new Error('Invalid ed2k link')
+  }
+
+  return { hash: normalizedHash, name: decodedName, size: parsedSize }
 }

--- a/src/amulerr/src/lib/naming.ts
+++ b/src/amulerr/src/lib/naming.ts
@@ -10,10 +10,14 @@ export function setReleaseGroup(name: string) {
 export function sanitizeUnicode(str: string) {
   const apostrophes = /[\u2018\u2019\u02BB\u02BC\u201B\u2032]/g
 
+  // ordinal / numero markers ("n°3", "n º3", "n№3") so issue numbers stay parseable
+  const ordinals = /[\u00B0\u00BA\u2116]/g
+
   return str
-    .normalize("NFKD")
-    .replace(apostrophes, " ")
-    .replace(/[\u0100-\uFFFF]/g, "")
+    .replace(ordinals, ' ')
+    .normalize('NFKD')
+    .replace(apostrophes, ' ')
+    .replace(/[\u0100-\uFFFF]/g, '')
 }
 
 export function sanitizeQuery(q: string): string
@@ -24,26 +28,26 @@ export function sanitizeQuery(q: string | undefined | null) {
   }
 
   return sanitizeUnicode(q)
-    .replace(/[^\w \(\)'-]/g, " ")
-    .replace(/ +/g, " ")
+    .replace(/[^\w \(\)'-]/g, ' ')
+    .replace(/ +/g, ' ')
     .trim()
 }
 
 export function sanitizeFilename(str: string) {
   // remove illegal characters
-  str = str.replace(/[/\\?%*:|"<>]/g, "_")
+  str = str.replace(/[/\\?%*:|"<>]/g, '_')
   str = sanitizeUnicode(str)
 
   // fix utf8 decoding artifacts
   while (true) {
     try {
-      const nstr = decodeURIComponent(escape(str));
+      const nstr = decodeURIComponent(escape(str))
       if (nstr === str) {
         break
       }
       str = nstr
     } catch (e) {
-      break;
+      break
     }
   }
 

--- a/src/amulerr/src/lib/qbittorrent-routes.test.ts
+++ b/src/amulerr/src/lib/qbittorrent-routes.test.ts
@@ -1,0 +1,975 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import path from 'node:path'
+import {
+  clampProgress,
+  defaultQbittorrentPreferences,
+  QBITTORRENT_UNKNOWN_ETA_SECONDS,
+  QBITTORRENT_WEBAPI_VERSION,
+  qbittorrentTorrentExtras,
+  torrentAmountLeft,
+  torrentEta,
+} from './qbittorrent'
+
+vi.mock('#/amule', () => ({
+  useAmule: vi.fn(async (fn: (client: unknown) => Promise<unknown>) =>
+    fn({
+      getDownloadQueue: async () => [],
+      getSharedFiles: async () => [],
+      getCategories: async () => [],
+    }),
+  ),
+}))
+
+vi.mock('node:fs/promises', () => ({
+  default: {
+    rm: vi.fn(async () => undefined),
+  },
+}))
+
+afterEach(async () => {
+  vi.clearAllMocks()
+  const { useAmule } = await import('#/amule')
+  vi.mocked(useAmule).mockImplementation(async (fn) =>
+    fn({
+      getDownloadQueue: async () => [],
+      getSharedFiles: async () => [],
+      getCategories: async () => [],
+    }),
+  )
+})
+
+type RouteHandler = (ctx: { request: Request }) => Promise<Response>
+
+function getHandler(
+  route: {
+    options?: {
+      server?: { handlers?: { GET?: RouteHandler; POST?: RouteHandler } }
+    }
+  },
+  method: 'GET' | 'POST' = 'GET',
+) {
+  const handler = route.options?.server?.handlers?.[method]
+  if (!handler) {
+    throw new Error(`Missing ${method} handler`)
+  }
+  return handler
+}
+
+describe('qbittorrent lib', () => {
+  it('returns safe preference defaults', () => {
+    const prefs = defaultQbittorrentPreferences()
+    expect(prefs.max_ratio_enabled).toBe(false)
+    expect(prefs.max_ratio).toBe(-1)
+    expect(prefs.max_seeding_time_enabled).toBe(false)
+    expect(prefs.max_seeding_time).toBe(-1)
+  })
+
+  it('adds stable torrent list extras', () => {
+    expect(qbittorrentTorrentExtras()).toEqual({
+      ratio: 0,
+      max_ratio: -1,
+      seeding_time: 0,
+      completion_on: -1,
+      uploaded: 0,
+      upspeed: 0,
+    })
+    expect(
+      qbittorrentTorrentExtras({ completionOn: 1700000000 }).completion_on,
+    ).toBe(1700000000)
+  })
+
+  it('clampProgress maps aMule percent to qBittorrent 0..1 fraction', () => {
+    expect(clampProgress(undefined)).toBe(0)
+    expect(clampProgress('50')).toBe(0.5)
+    expect(clampProgress(50)).toBe(0.5)
+    expect(clampProgress('100')).toBe(1)
+    expect(clampProgress(100)).toBe(1)
+    expect(clampProgress('150')).toBe(1)
+    expect(clampProgress(-5)).toBe(0)
+  })
+
+  it('torrentAmountLeft never returns negative values', () => {
+    expect(torrentAmountLeft(100, 50)).toBe(50)
+    expect(torrentAmountLeft(100, 150)).toBe(0)
+  })
+
+  it('torrentEta returns integer seconds for qBittorrent compatibility', () => {
+    expect(torrentEta(10, 50)).toBe(5)
+    expect(torrentEta(10, 0)).toBe(0)
+    expect(torrentEta(0, 50)).toBe(QBITTORRENT_UNKNOWN_ETA_SECONDS)
+    expect(torrentEta(3, 50)).toBe(17)
+    expect(Number.isInteger(torrentEta(3, 50))).toBe(true)
+  })
+})
+
+describe('app routes', () => {
+  it('/api/v2/app/webapiVersion returns text/plain semver', async () => {
+    const { Route } = await import('#/routes/api.v2.app.webapiVersion')
+    const response = await getHandler(Route)({
+      request: new Request('http://x/api/v2/app/webapiVersion'),
+    })
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('text/plain')
+    expect(await response.text()).toBe(QBITTORRENT_WEBAPI_VERSION)
+  })
+
+  it('/api/v2/app/version returns qBittorrent-like version text', async () => {
+    const { Route } = await import('#/routes/api.v2.app.version')
+    const response = await getHandler(Route)({
+      request: new Request('http://x/api/v2/app/version'),
+    })
+    expect(response.headers.get('Content-Type')).toBe('text/plain')
+    expect(await response.text()).toMatch(/^v/)
+  })
+
+  it('/api/v2/app/preferences returns required JSON fields', async () => {
+    const { Route } = await import('#/routes/api.v2.app.preferences')
+    const response = await getHandler(Route)({
+      request: new Request('http://x/api/v2/app/preferences'),
+    })
+    const body = await response.json()
+    expect(body.max_ratio_enabled).toBe(false)
+    expect(body.max_seeding_time).toBe(-1)
+  })
+
+  it('/api/v2/auth/login returns Ok. and SID cookie', async () => {
+    const { Route } = await import('#/routes/api.v2.auth.login')
+    const response = await getHandler(
+      Route,
+      'POST',
+    )({ request: new Request('http://x') })
+    expect(await response.text()).toBe('Ok.')
+    expect(response.headers.get('Set-Cookie')).toContain('SID=')
+    expect(response.headers.get('Cache-Control')).toBe('no-store')
+  })
+
+  it('/api/v2/auth/login adds Secure to SID cookie over HTTPS', async () => {
+    const { Route } = await import('#/routes/api.v2.auth.login')
+    const response = await getHandler(
+      Route,
+      'POST',
+    )({
+      request: new Request('https://x/api/v2/auth/login'),
+    })
+    expect(response.headers.get('Set-Cookie')).toContain('; Secure')
+  })
+
+  it('/api/v2/auth/logout adds Secure when behind HTTPS proxy', async () => {
+    const { Route } = await import('#/routes/api.v2.auth.logout')
+    const response = await getHandler(
+      Route,
+      'POST',
+    )({
+      request: new Request('http://x/api/v2/auth/logout', {
+        headers: { 'X-Forwarded-Proto': 'https' },
+      }),
+    })
+    expect(response.headers.get('Set-Cookie')).toContain('; Secure')
+  })
+})
+
+describe('torrents/properties', () => {
+  it('returns 404 for invalid hash without calling aMule', async () => {
+    const { useAmule } = await import('#/amule')
+    const { Route } = await import('#/routes/api.v2.torrents.properties')
+    const request = new Request(
+      'http://x/api/v2/torrents/properties?hash=notvalid',
+    )
+    const response = await getHandler(Route)({ request })
+    expect(response.status).toBe(404)
+    expect(useAmule).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 for missing torrent', async () => {
+    const { Route } = await import('#/routes/api.v2.torrents.properties')
+    const hash = `${'a'.repeat(32)}00000000`
+    const request = new Request(
+      `http://x/api/v2/torrents/properties?hash=${hash}`,
+    )
+    const response = await getHandler(Route)({ request })
+    expect(response.status).toBe(404)
+  })
+})
+
+describe('no-op torrent routes', () => {
+  const postRequest = { request: new Request('http://x', { method: 'POST' }) }
+
+  it('setShareLimits returns Ok', async () => {
+    const { Route } = await import('#/routes/api.v2.torrents.setShareLimits')
+    const response = await getHandler(Route, 'POST')(postRequest)
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('text/plain')
+    expect(await response.text()).toBe('Ok')
+  })
+
+  it('topPrio returns Ok', async () => {
+    const { Route } = await import('#/routes/api.v2.torrents.topPrio')
+    const response = await getHandler(Route, 'POST')(postRequest)
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('text/plain')
+    expect(await response.text()).toBe('Ok')
+  })
+
+  it('setForceStart returns Ok', async () => {
+    const { Route } = await import('#/routes/api.v2.torrents.setForceStart')
+    const response = await getHandler(Route, 'POST')(postRequest)
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('text/plain')
+    expect(await response.text()).toBe('Ok')
+  })
+})
+
+const ED2K = 'A1B2C3D4E5F60718293A4B5C6D7E8F90'
+const BTIH = `${ED2K.toLowerCase()}00000000`
+
+describe('torrents/info', () => {
+  async function getInfoTorrent(
+    progress: string,
+    fileSize = 100,
+    fileSizeDownloaded = 50,
+    speed = 10,
+  ) {
+    const { useAmule } = await import('#/amule')
+    vi.mocked(useAmule).mockImplementationOnce(async (fn) =>
+      fn({
+        getDownloadQueue: async () => [
+          {
+            fileHash: ED2K,
+            fileName: 'book.pdf',
+            fileSize,
+            fileSizeDownloaded,
+            progress,
+            speed,
+            status: 3,
+          },
+        ],
+        getSharedFiles: async () => [],
+        getCategories: async () => [],
+      }),
+    )
+    const { Route } = await import('#/routes/api.v2.torrents.info')
+    const response = await getHandler(Route)({
+      request: new Request('http://x/api/v2/torrents/info'),
+    })
+    expect(response.status).toBe(200)
+    return (await response.json())[0]
+  }
+
+  it('returns progress 1 when aMule reports 100', async () => {
+    const torrent = await getInfoTorrent('100', 100, 100)
+    expect(torrent.progress).toBe(1)
+  })
+
+  it('returns progress 1 when aMule reports over 100', async () => {
+    const torrent = await getInfoTorrent('150', 100, 100)
+    expect(torrent.progress).toBe(1)
+  })
+
+  it('returns progress 0.5 when aMule reports 50', async () => {
+    const torrent = await getInfoTorrent('50', 100, 50)
+    expect(torrent.progress).toBe(0.5)
+  })
+
+  it('returns amount_left 0 when downloaded exceeds size', async () => {
+    const torrent = await getInfoTorrent('100', 100, 150, 10)
+    expect(torrent.amount_left).toBe(0)
+  })
+
+  it('returns non-negative eta when downloaded exceeds size', async () => {
+    const torrent = await getInfoTorrent('100', 100, 150, 10)
+    expect(torrent.eta).toBeGreaterThanOrEqual(0)
+    expect(torrent.eta).toBe(0)
+  })
+
+  it('returns completion_on -1 for finished downloads and shared files', async () => {
+    const { useAmule } = await import('#/amule')
+    vi.mocked(useAmule).mockImplementationOnce(async (fn) =>
+      fn({
+        getDownloadQueue: async () => [
+          {
+            fileHash: ED2K,
+            fileName: 'done.pdf',
+            fileSize: 100,
+            fileSizeDownloaded: 100,
+            progress: '100',
+            speed: 0,
+            status: 9,
+          },
+        ],
+        getSharedFiles: async () => [
+          {
+            fileHash: 'B1B2C3D4E5F60718293A4B5C6D7E8F91',
+            fileName: 'shared.pdf',
+            fileSize: 42,
+            path: '/shared',
+          },
+        ],
+        getCategories: async () => [],
+      }),
+    )
+    const { Route } = await import('#/routes/api.v2.torrents.info')
+    const response = await getHandler(Route)({
+      request: new Request('http://x/api/v2/torrents/info'),
+    })
+    const body = await response.json()
+    expect(body[0].completion_on).toBe(-1)
+    expect(body[1].completion_on).toBe(-1)
+  })
+
+  it('returns stable completion_on across repeated info polls', async () => {
+    const { useAmule } = await import('#/amule')
+    vi.mocked(useAmule).mockImplementation(async (fn) =>
+      fn({
+        getDownloadQueue: async () => [
+          {
+            fileHash: ED2K,
+            fileName: 'done.pdf',
+            fileSize: 100,
+            fileSizeDownloaded: 100,
+            progress: '100',
+            speed: 0,
+            status: 9,
+          },
+        ],
+        getSharedFiles: async () => [],
+        getCategories: async () => [],
+      }),
+    )
+    const { Route } = await import('#/routes/api.v2.torrents.info')
+    const handler = getHandler(Route)
+    const request = { request: new Request('http://x/api/v2/torrents/info') }
+    const first = await (await handler(request)).json()
+    const second = await (await handler(request)).json()
+    expect(first[0].completion_on).toBe(-1)
+    expect(second[0].completion_on).toBe(-1)
+    expect(first[0].completion_on).toBe(second[0].completion_on)
+  })
+
+  it('leaves completion_on at -1 for in-progress downloads', async () => {
+    const torrent = await getInfoTorrent('50', 100, 50)
+    expect(torrent.completion_on).toBe(-1)
+  })
+
+  it('deduplicates shared files against downloads case-insensitively', async () => {
+    const { useAmule } = await import('#/amule')
+    vi.mocked(useAmule).mockImplementationOnce(async (fn) =>
+      fn({
+        getDownloadQueue: async () => [
+          {
+            fileHash: ED2K,
+            fileName: 'downloading.pdf',
+            fileSize: 100,
+            fileSizeDownloaded: 50,
+            progress: '50',
+            speed: 10,
+            status: 3,
+          },
+        ],
+        getSharedFiles: async () => [
+          {
+            fileHash: ED2K.toLowerCase(),
+            fileName: 'shared-same-hash.pdf',
+            fileSize: 100,
+            path: '/shared',
+          },
+        ],
+        getCategories: async () => [],
+      }),
+    )
+    const { Route } = await import('#/routes/api.v2.torrents.info')
+    const response = await getHandler(Route)({
+      request: new Request('http://x/api/v2/torrents/info'),
+    })
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toHaveLength(1)
+    expect(body[0].name).toBe('downloading.pdf')
+  })
+
+  it('returns empty array for unknown category filter', async () => {
+    const { useAmule } = await import('#/amule')
+    vi.mocked(useAmule).mockImplementationOnce(async (fn) =>
+      fn({
+        getDownloadQueue: async () => [
+          {
+            fileHash: ED2K,
+            fileName: 'book.pdf',
+            fileSize: 100,
+            fileSizeDownloaded: 50,
+            progress: '50',
+            speed: 10,
+            status: 3,
+            category: 1,
+          },
+        ],
+        getSharedFiles: async () => [],
+        getCategories: async () => [{ id: 1, title: 'books', path: '/books' }],
+      }),
+    )
+    const { Route } = await import('#/routes/api.v2.torrents.info')
+    const response = await getHandler(Route)({
+      request: new Request('http://x/api/v2/torrents/info?category=missing'),
+    })
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual([])
+  })
+})
+
+describe('torrents/files and torrents/contents', () => {
+  it('GET /torrents/files returns 404 for invalid hash without aMule', async () => {
+    const { useAmule } = await import('#/amule')
+    vi.mocked(useAmule).mockClear()
+    const { Route } = await import('#/routes/api.v2.torrents.files')
+    const response = await getHandler(Route)({
+      request: new Request('http://x/api/v2/torrents/files?hash=bad'),
+    })
+    expect(response.status).toBe(404)
+    expect(await response.json()).toEqual([])
+    expect(useAmule).not.toHaveBeenCalled()
+  })
+
+  it('GET /torrents/files returns partial download with 0..1 progress and is_seed false', async () => {
+    const { useAmule } = await import('#/amule')
+    vi.mocked(useAmule).mockImplementationOnce(async (fn) =>
+      fn({
+        getDownloadQueue: async () => [
+          {
+            fileHash: ED2K,
+            fileName: 'book.pdf',
+            fileSize: 100,
+            fileSizeDownloaded: 50,
+          },
+        ],
+        getSharedFiles: async () => [],
+      }),
+    )
+    const { Route } = await import('#/routes/api.v2.torrents.files')
+    const response = await getHandler(Route)({
+      request: new Request(`http://x/api/v2/torrents/files?hash=${BTIH}`),
+    })
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toEqual([
+      {
+        index: 0,
+        name: 'book.pdf',
+        size: 100,
+        progress: 0.5,
+        priority: 1,
+        is_seed: false,
+        availability: 1,
+      },
+    ])
+    expect(body[0].progress).toBeGreaterThanOrEqual(0)
+    expect(body[0].progress).toBeLessThanOrEqual(1)
+  })
+
+  it('GET /torrents/files defaults missing name/size and uses zero progress', async () => {
+    const { useAmule } = await import('#/amule')
+    vi.mocked(useAmule).mockImplementationOnce(async (fn) =>
+      fn({
+        getDownloadQueue: async () => [{ fileHash: ED2K }],
+        getSharedFiles: async () => [],
+      }),
+    )
+    const { Route } = await import('#/routes/api.v2.torrents.files')
+    const response = await getHandler(Route)({
+      request: new Request(`http://x/api/v2/torrents/files?hash=${BTIH}`),
+    })
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual([
+      {
+        index: 0,
+        name: '',
+        size: 0,
+        progress: 0,
+        priority: 1,
+        is_seed: false,
+        availability: 1,
+      },
+    ])
+  })
+
+  it('GET /torrents/files returns completed download with progress 1 and is_seed true', async () => {
+    const { useAmule } = await import('#/amule')
+    vi.mocked(useAmule).mockImplementationOnce(async (fn) =>
+      fn({
+        getDownloadQueue: async () => [
+          {
+            fileHash: ED2K,
+            fileName: 'book.pdf',
+            fileSize: 100,
+            fileSizeDownloaded: 100,
+          },
+        ],
+        getSharedFiles: async () => [],
+      }),
+    )
+    const { Route } = await import('#/routes/api.v2.torrents.files')
+    const response = await getHandler(Route)({
+      request: new Request(`http://x/api/v2/torrents/files?hash=${BTIH}`),
+    })
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual([
+      {
+        index: 0,
+        name: 'book.pdf',
+        size: 100,
+        progress: 1,
+        priority: 1,
+        is_seed: true,
+        availability: 1,
+      },
+    ])
+  })
+
+  it('GET /torrents/files returns shared file with progress 1 and is_seed true', async () => {
+    const { useAmule } = await import('#/amule')
+    vi.mocked(useAmule).mockImplementationOnce(async (fn) =>
+      fn({
+        getDownloadQueue: async () => [],
+        getSharedFiles: async () => [
+          {
+            fileHash: ED2K,
+            fileName: 'shared.pdf',
+            fileSize: 42,
+          },
+        ],
+      }),
+    )
+    const { Route } = await import('#/routes/api.v2.torrents.files')
+    const response = await getHandler(Route)({
+      request: new Request(`http://x/api/v2/torrents/files?hash=${BTIH}`),
+    })
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual([
+      {
+        index: 0,
+        name: 'shared.pdf',
+        size: 42,
+        progress: 1,
+        priority: 1,
+        is_seed: true,
+        availability: 1,
+      },
+    ])
+  })
+
+  it('POST /torrents/contents mirrors GET /torrents/files for the same hash', async () => {
+    const { useAmule } = await import('#/amule')
+    const amuleData = {
+      getDownloadQueue: async () => [
+        {
+          fileHash: ED2K,
+          fileName: 'book.pdf',
+          fileSize: 100,
+          fileSizeDownloaded: 25,
+        },
+      ],
+      getSharedFiles: async () => [],
+    }
+    vi.mocked(useAmule)
+      .mockImplementationOnce(async (fn) => fn(amuleData))
+      .mockImplementationOnce(async (fn) => fn(amuleData))
+
+    const { Route: filesRoute } = await import('#/routes/api.v2.torrents.files')
+    const filesResponse = await getHandler(filesRoute)({
+      request: new Request(`http://x/api/v2/torrents/files?hash=${BTIH}`),
+    })
+
+    const { Route: contentsRoute } =
+      await import('#/routes/api.v2.torrents.contents')
+    const contentsResponse = await getHandler(
+      contentsRoute,
+      'POST',
+    )({
+      request: new Request('http://x/api/v2/torrents/contents', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ hash: BTIH }),
+      }),
+    })
+
+    expect(filesResponse.status).toBe(200)
+    expect(contentsResponse.status).toBe(200)
+    expect(await contentsResponse.json()).toEqual(await filesResponse.json())
+  })
+
+  it('POST /torrents/contents falls back to query hash when body hash is empty', async () => {
+    const { useAmule } = await import('#/amule')
+    vi.mocked(useAmule).mockImplementationOnce(async (fn) =>
+      fn({
+        getDownloadQueue: async () => [
+          {
+            fileHash: ED2K,
+            fileName: 'book.pdf',
+            fileSize: 100,
+            fileSizeDownloaded: 50,
+          },
+        ],
+        getSharedFiles: async () => [],
+      }),
+    )
+    const { Route } = await import('#/routes/api.v2.torrents.contents')
+    const response = await getHandler(
+      Route,
+      'POST',
+    )({
+      request: new Request(`http://x/api/v2/torrents/contents?hash=${BTIH}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ hash: '' }),
+      }),
+    })
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual([
+      {
+        index: 0,
+        name: 'book.pdf',
+        size: 100,
+        progress: 0.5,
+        priority: 1,
+        is_seed: false,
+        availability: 1,
+      },
+    ])
+  })
+
+  it('POST /torrents/contents returns 404 for invalid hash', async () => {
+    const { useAmule } = await import('#/amule')
+    vi.mocked(useAmule).mockClear()
+    const { Route } = await import('#/routes/api.v2.torrents.contents')
+    const body = new URLSearchParams({ hash: 'not-a-hash' })
+    const response = await getHandler(
+      Route,
+      'POST',
+    )({
+      request: new Request('http://x/api/v2/torrents/contents', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body,
+      }),
+    })
+    expect(response.status).toBe(404)
+    expect(await response.json()).toEqual([])
+    expect(useAmule).not.toHaveBeenCalled()
+  })
+
+  it('POST /torrents/contents returns 404 for unknown hash', async () => {
+    const { Route } = await import('#/routes/api.v2.torrents.contents')
+    const body = new URLSearchParams({ hash: BTIH })
+    const response = await getHandler(
+      Route,
+      'POST',
+    )({
+      request: new Request('http://x/api/v2/torrents/contents', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body,
+      }),
+    })
+    expect(response.status).toBe(404)
+    expect(await response.json()).toEqual([])
+  })
+
+  it('GET /torrents/files returns 404 for unknown hash', async () => {
+    const { Route } = await import('#/routes/api.v2.torrents.files')
+    const response = await getHandler(Route)({
+      request: new Request(`http://x/api/v2/torrents/files?hash=${BTIH}`),
+    })
+    expect(response.status).toBe(404)
+    expect(await response.json()).toEqual([])
+  })
+})
+
+describe('torrents/add', () => {
+  const magnet = `magnet:?xt=urn:btih:${BTIH}&dn=${encodeURIComponent('book.pdf')}&xl=100&tr=http://amulerr`
+
+  async function postAdd(form: Record<string, string>) {
+    const { Route } = await import('#/routes/api.v2.torrents.add')
+    return getHandler(
+      Route,
+      'POST',
+    )({
+      request: new Request('http://x/api/v2/torrents/add', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams(form),
+      }),
+    })
+  }
+
+  it('returns 400 when urls is missing', async () => {
+    const { useAmule } = await import('#/amule')
+    const response = await postAdd({ category: 'books' })
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe('Missing urls parameter')
+    expect(useAmule).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when category is missing or blank', async () => {
+    const { useAmule } = await import('#/amule')
+    const missing = await postAdd({ urls: magnet })
+    expect(missing.status).toBe(400)
+    expect(await missing.text()).toBe('Missing category parameter')
+
+    const blank = await postAdd({ urls: magnet, category: '   ' })
+    expect(blank.status).toBe(400)
+    expect(await blank.text()).toBe('Missing category parameter')
+    expect(useAmule).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 for invalid magnet links', async () => {
+    const { useAmule } = await import('#/amule')
+    const response = await postAdd({ urls: 'not-a-magnet', category: 'books' })
+    expect(response.status).toBe(400)
+    expect(await response.text()).toBe('Invalid magnet link')
+    expect(useAmule).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 for unknown category', async () => {
+    const { useAmule } = await import('#/amule')
+    vi.mocked(useAmule).mockImplementationOnce(async (fn) =>
+      fn({
+        getDownloadQueue: async () => [],
+        getSharedFiles: async () => [],
+        getCategories: async () => [{ id: 1, title: 'books', path: '/books' }],
+        addEd2kLink: vi.fn(async () => true),
+      }),
+    )
+    const response = await postAdd({ urls: magnet, category: 'missing' })
+    expect(response.status).toBe(404)
+    expect(await response.text()).toBe('Category missing not found')
+  })
+
+  it('returns 200 when torrent is already present', async () => {
+    const { useAmule } = await import('#/amule')
+    const addEd2kLink = vi.fn(async () => true)
+    vi.mocked(useAmule).mockImplementationOnce(async (fn) =>
+      fn({
+        getDownloadQueue: async () => [{ fileHash: ED2K }],
+        getSharedFiles: async () => [],
+        getCategories: async () => [{ id: 1, title: 'books', path: '/books' }],
+        addEd2kLink,
+      }),
+    )
+    const response = await postAdd({ urls: magnet, category: 'books' })
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({})
+    expect(addEd2kLink).not.toHaveBeenCalled()
+  })
+
+  it('treats failed add as success when torrent appears after re-check', async () => {
+    const { useAmule } = await import('#/amule')
+    let present = false
+    const addEd2kLink = vi.fn(async () => {
+      present = true
+      return false
+    })
+    vi.mocked(useAmule).mockImplementationOnce(async (fn) =>
+      fn({
+        getDownloadQueue: async () => (present ? [{ fileHash: ED2K }] : []),
+        getSharedFiles: async () => [],
+        getCategories: async () => [{ id: 1, title: 'books', path: '/books' }],
+        addEd2kLink,
+      }),
+    )
+    const response = await postAdd({ urls: magnet, category: 'books' })
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({})
+    expect(addEd2kLink).toHaveBeenCalledOnce()
+  })
+})
+
+const OTHER_ED2K = 'B1B2C3D4E5F60718293A4B5C6D7E8F91'
+
+describe('torrents/delete', () => {
+  async function postDelete(
+    hashes: string,
+    options?: { deleteFiles?: string },
+  ) {
+    const params = new URLSearchParams({ hashes })
+    if (options?.deleteFiles !== undefined) {
+      params.set('deleteFiles', options.deleteFiles)
+    }
+
+    const { Route } = await import('#/routes/api.v2.torrents.delete')
+    return getHandler(
+      Route,
+      'POST',
+    )({
+      request: new Request('http://x/api/v2/torrents/delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: params,
+      }),
+    })
+  }
+
+  const sharedWithPaths = [
+    {
+      ecid: 101,
+      fileHash: ED2K.toLowerCase(),
+      path: '/downloads',
+      fileName: 'book.epub',
+    },
+    {
+      ecid: 202,
+      fileHash: OTHER_ED2K,
+      path: '/downloads',
+      fileName: 'other.epub',
+    },
+  ]
+
+  it('clears all shared ecids when hashes=all', async () => {
+    const { useAmule } = await import('#/amule')
+    const clearCompleted = vi.fn(async () => true)
+    const cancelDownload = vi.fn(async () => true)
+    vi.mocked(useAmule).mockImplementationOnce(async (fn) =>
+      fn({
+        getDownloadQueue: async () => [{ fileHash: ED2K }],
+        getSharedFiles: async () => [
+          { ecid: 101, fileHash: ED2K },
+          { ecid: 202, fileHash: OTHER_ED2K },
+        ],
+        clearCompleted,
+        cancelDownload,
+      }),
+    )
+
+    const response = await postDelete('all', { deleteFiles: 'false' })
+    expect(response.status).toBe(200)
+    expect(clearCompleted).toHaveBeenCalledWith([101, 202])
+    expect(cancelDownload).toHaveBeenCalledWith(ED2K)
+  })
+
+  it('clears only the matching shared ecid for a specific hash', async () => {
+    const { useAmule } = await import('#/amule')
+    const clearCompleted = vi.fn(async () => true)
+    const cancelDownload = vi.fn(async () => true)
+    vi.mocked(useAmule).mockImplementationOnce(async (fn) =>
+      fn({
+        getDownloadQueue: async () => [],
+        getSharedFiles: async () => [
+          { ecid: 101, fileHash: ED2K.toLowerCase() },
+          { ecid: 202, fileHash: OTHER_ED2K },
+        ],
+        clearCompleted,
+        cancelDownload,
+      }),
+    )
+
+    const response = await postDelete(BTIH, { deleteFiles: 'false' })
+    expect(response.status).toBe(200)
+    expect(clearCompleted).toHaveBeenCalledWith([101])
+    expect(cancelDownload).toHaveBeenCalledWith(ED2K)
+  })
+
+  it('does not delete files or refresh shared files when deleteFiles=false', async () => {
+    const fs = await import('node:fs/promises')
+    const { useAmule } = await import('#/amule')
+    const clearCompleted = vi.fn(async () => true)
+    const cancelDownload = vi.fn(async () => true)
+    const refreshSharedFiles = vi.fn(async () => true)
+    vi.mocked(useAmule).mockImplementationOnce(async (fn) =>
+      fn({
+        getDownloadQueue: async () => [],
+        getSharedFiles: async () => sharedWithPaths,
+        clearCompleted,
+        cancelDownload,
+        refreshSharedFiles,
+      }),
+    )
+
+    const response = await postDelete(BTIH, { deleteFiles: 'false' })
+    expect(response.status).toBe(200)
+    expect(vi.mocked(fs.default.rm)).not.toHaveBeenCalled()
+    expect(refreshSharedFiles).not.toHaveBeenCalled()
+  })
+
+  it('deletes matching files and refreshes shared files when deleteFiles=true', async () => {
+    const fs = await import('node:fs/promises')
+    const { useAmule } = await import('#/amule')
+    const clearCompleted = vi.fn(async () => true)
+    const cancelDownload = vi.fn(async () => true)
+    const refreshSharedFiles = vi.fn(async () => true)
+    vi.mocked(useAmule).mockImplementationOnce(async (fn) =>
+      fn({
+        getDownloadQueue: async () => [],
+        getSharedFiles: async () => sharedWithPaths,
+        clearCompleted,
+        cancelDownload,
+        refreshSharedFiles,
+      }),
+    )
+
+    const response = await postDelete(BTIH, { deleteFiles: 'true' })
+    expect(response.status).toBe(200)
+    expect(vi.mocked(fs.default.rm)).toHaveBeenCalledOnce()
+    expect(vi.mocked(fs.default.rm)).toHaveBeenCalledWith(
+      path.join('/downloads', 'book.epub'),
+      { force: true },
+    )
+    expect(refreshSharedFiles).toHaveBeenCalledOnce()
+  })
+
+  it('deletes files by default when deleteFiles is omitted', async () => {
+    const fs = await import('node:fs/promises')
+    const { useAmule } = await import('#/amule')
+    const refreshSharedFiles = vi.fn(async () => true)
+    vi.mocked(useAmule).mockImplementationOnce(async (fn) =>
+      fn({
+        getDownloadQueue: async () => [],
+        getSharedFiles: async () => sharedWithPaths,
+        clearCompleted: vi.fn(async () => true),
+        cancelDownload: vi.fn(async () => true),
+        refreshSharedFiles,
+      }),
+    )
+
+    const response = await postDelete(BTIH)
+    expect(response.status).toBe(200)
+    expect(vi.mocked(fs.default.rm)).toHaveBeenCalledOnce()
+    expect(refreshSharedFiles).toHaveBeenCalledOnce()
+  })
+
+  it('deletes all shared files when hashes=all and deleteFiles=true', async () => {
+    const fs = await import('node:fs/promises')
+    const { useAmule } = await import('#/amule')
+    const refreshSharedFiles = vi.fn(async () => true)
+    vi.mocked(useAmule).mockImplementationOnce(async (fn) =>
+      fn({
+        getDownloadQueue: async () => [{ fileHash: ED2K }],
+        getSharedFiles: async () => sharedWithPaths,
+        clearCompleted: vi.fn(async () => true),
+        cancelDownload: vi.fn(async () => true),
+        refreshSharedFiles,
+      }),
+    )
+
+    const response = await postDelete('all', { deleteFiles: 'true' })
+    expect(response.status).toBe(200)
+    expect(vi.mocked(fs.default.rm)).toHaveBeenCalledTimes(2)
+    expect(refreshSharedFiles).toHaveBeenCalledOnce()
+  })
+
+  it('does not delete files when hashes=all and deleteFiles=false', async () => {
+    const fs = await import('node:fs/promises')
+    const { useAmule } = await import('#/amule')
+    const refreshSharedFiles = vi.fn(async () => true)
+    vi.mocked(useAmule).mockImplementationOnce(async (fn) =>
+      fn({
+        getDownloadQueue: async () => [{ fileHash: ED2K }],
+        getSharedFiles: async () => sharedWithPaths,
+        clearCompleted: vi.fn(async () => true),
+        cancelDownload: vi.fn(async () => true),
+        refreshSharedFiles,
+      }),
+    )
+
+    const response = await postDelete('all', { deleteFiles: 'false' })
+    expect(response.status).toBe(200)
+    expect(vi.mocked(fs.default.rm)).not.toHaveBeenCalled()
+    expect(refreshSharedFiles).not.toHaveBeenCalled()
+  })
+})

--- a/src/amulerr/src/lib/qbittorrent.ts
+++ b/src/amulerr/src/lib/qbittorrent.ts
@@ -1,0 +1,85 @@
+export const QBITTORRENT_WEBAPI_VERSION = '2.11.0'
+export const QBITTORRENT_APP_VERSION = 'v4.6.7'
+
+/** qBittorrent returns 8640000 s (100 days) when download speed is zero and ETA is unknown. */
+export const QBITTORRENT_UNKNOWN_ETA_SECONDS = 8640000
+
+export function qbittorrentPlainTextResponse(
+  body: string,
+  cacheControl = 'public, max-age=0',
+) {
+  return new Response(body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/plain',
+      'X-Content-Type-Options': 'nosniff',
+      'Cache-Control': cacheControl,
+    },
+  })
+}
+
+/** Safe defaults for *rr / LazyLibrarian preference polling (ratio/seeding limits disabled). */
+export function defaultQbittorrentPreferences() {
+  return {
+    save_path: '/downloads/complete',
+    temp_path_enabled: false,
+    temp_path: '/downloads/incomplete',
+    create_subfolder_enabled: false,
+    max_ratio_enabled: false,
+    max_ratio: -1,
+    max_seeding_time_enabled: false,
+    max_seeding_time: -1,
+  }
+}
+
+/** Extra qBittorrent torrent list fields expected by Sonarr/Radarr/LazyLibrarian/PyMedusa. */
+export function qbittorrentTorrentExtras(
+  options: {
+    completionOn?: number
+  } = {},
+) {
+  return {
+    ratio: 0,
+    max_ratio: -1,
+    seeding_time: 0,
+    completion_on: options.completionOn ?? -1,
+    uploaded: 0,
+    upspeed: 0,
+  }
+}
+
+/** aMule progress is 0..100; qBittorrent torrent list uses a 0..1 fraction. */
+export function clampProgress(
+  rawProgress: string | number | undefined,
+): number {
+  if (rawProgress === undefined || rawProgress === '') {
+    return 0
+  }
+
+  const percent =
+    typeof rawProgress === 'number' ? rawProgress : parseFloat(rawProgress)
+  if (!Number.isFinite(percent) || percent < 0) {
+    return 0
+  }
+  if (percent >= 100) {
+    return 1
+  }
+  return percent / 100
+}
+
+export function torrentAmountLeft(
+  fileSize: number,
+  fileSizeDownloaded: number,
+) {
+  return Math.max(0, fileSize - fileSizeDownloaded)
+}
+
+export function torrentEta(dlspeed: number, amountLeft: number) {
+  if (amountLeft <= 0) {
+    return 0
+  }
+  if (dlspeed > 0) {
+    return Math.ceil(amountLeft / dlspeed)
+  }
+  return QBITTORRENT_UNKNOWN_ETA_SECONDS
+}

--- a/src/amulerr/src/lib/torrent-files.ts
+++ b/src/amulerr/src/lib/torrent-files.ts
@@ -1,0 +1,125 @@
+import { useAmule } from '#/amule'
+import { sameEd2kHash } from '#/lib/links'
+import { parseTorrentHash } from '#/lib/torrents'
+
+export type TorrentFileEntry = {
+  index: number
+  name: string
+  size: number
+  progress: number
+  priority: number
+  is_seed: boolean
+  availability: number
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value))
+}
+
+function downloadProgress(fileSize: number, fileSizeDownloaded: number) {
+  if (fileSize <= 0) {
+    return 0
+  }
+  return clamp(fileSizeDownloaded / fileSize, 0, 1)
+}
+
+function isFullyDownloaded(fileSize: number, fileSizeDownloaded: number) {
+  return fileSize > 0 && fileSizeDownloaded >= fileSize
+}
+
+export function toDownloadFileEntry(download: {
+  fileName?: string
+  fileSize?: number
+  fileSizeDownloaded?: number
+}): TorrentFileEntry {
+  const name = download.fileName ?? ''
+  const size = download.fileSize ?? 0
+  const downloaded = download.fileSizeDownloaded ?? 0
+  const progress = downloadProgress(size, downloaded)
+
+  return {
+    index: 0,
+    name,
+    size,
+    progress,
+    priority: 1,
+    is_seed: isFullyDownloaded(size, downloaded),
+    availability: 1,
+  }
+}
+
+export function toSharedFileEntry(sharedFile: {
+  fileName?: string
+  fileSize?: number
+}): TorrentFileEntry {
+  const name = sharedFile.fileName ?? ''
+  const size = sharedFile.fileSize ?? 0
+
+  return {
+    index: 0,
+    name,
+    size,
+    progress: 1,
+    priority: 1,
+    is_seed: true,
+    availability: 1,
+  }
+}
+
+export async function extractTorrentHash(
+  request: Request,
+): Promise<string | null> {
+  const fromQuery = new URL(request.url).searchParams.get('hash')
+
+  if (request.method === 'GET') {
+    return fromQuery
+  }
+
+  const contentType = request.headers.get('content-type') ?? ''
+  if (
+    contentType.includes('multipart/form-data') ||
+    contentType.includes('application/x-www-form-urlencoded')
+  ) {
+    const formData = await request.formData()
+    const fromBody = (formData.get('hash') ?? '').toString().trim()
+    return fromBody || fromQuery
+  }
+
+  return fromQuery
+}
+
+export async function getTorrentFilesResponse(
+  rawHash: string | null | undefined,
+): Promise<Response> {
+  if (!rawHash) {
+    return Response.json([], { status: 404 })
+  }
+
+  const hash = parseTorrentHash(rawHash)
+  if (!hash) {
+    return Response.json([], { status: 404 })
+  }
+
+  const file = await useAmule(async (amule) => {
+    const downloads = await amule.getDownloadQueue()
+    const shared = await amule.getSharedFiles()
+
+    const download = downloads.find((item) => sameEd2kHash(item.fileHash, hash))
+    if (download) {
+      return toDownloadFileEntry(download)
+    }
+
+    const sharedFile = shared.find((item) => sameEd2kHash(item.fileHash, hash))
+    if (sharedFile) {
+      return toSharedFileEntry(sharedFile)
+    }
+
+    return null
+  })
+
+  if (!file) {
+    return Response.json([], { status: 404 })
+  }
+
+  return Response.json([file])
+}

--- a/src/amulerr/src/lib/torrents.test.ts
+++ b/src/amulerr/src/lib/torrents.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  ed2kHashSet,
+  hasTorrentHashInput,
+  normalizeEd2kHash,
+  parseTorrentHash,
+  resolveTorrentHashes,
+  sameEd2kHash,
+} from './torrents'
+
+const ED2K = 'A1B2C3D4E5F60718293A4B5C6D7E8F90'
+const BTIH = `${ED2K.toLowerCase()}00000000`
+
+describe('parseTorrentHash', () => {
+  it('accepts exact 32-hex ed2k', () => {
+    expect(parseTorrentHash(ED2K)).toBe(ED2K)
+    expect(normalizeEd2kHash(ED2K.toLowerCase())).toBe(ED2K)
+  })
+
+  it('accepts exact 40-hex amulerr btih', () => {
+    expect(parseTorrentHash(BTIH)).toBe(ED2K)
+  })
+
+  it('rejects invalid hashes', () => {
+    expect(parseTorrentHash('not-a-hash')).toBeNull()
+    expect(parseTorrentHash(`${ED2K}garbage`)).toBeNull()
+    expect(parseTorrentHash('b'.repeat(40))).toBeNull()
+    expect(parseTorrentHash('|')).toBeNull()
+    expect(parseTorrentHash('')).toBeNull()
+  })
+})
+
+describe('sameEd2kHash', () => {
+  it('matches hashes case-insensitively', () => {
+    expect(sameEd2kHash(ED2K, ED2K.toLowerCase())).toBe(true)
+    expect(sameEd2kHash(ED2K, BTIH)).toBe(true)
+  })
+})
+
+describe('ed2kHashSet', () => {
+  it('normalizes hashes in a set', () => {
+    expect(ed2kHashSet([ED2K.toLowerCase(), 'bad'])).toEqual(new Set([ED2K]))
+  })
+})
+
+describe('hasTorrentHashInput', () => {
+  it('accepts all and valid hashes only', () => {
+    expect(hasTorrentHashInput('all')).toBe(true)
+    expect(hasTorrentHashInput(ED2K)).toBe(true)
+    expect(hasTorrentHashInput('|')).toBe(false)
+    expect(hasTorrentHashInput('  |  ')).toBe(false)
+    expect(hasTorrentHashInput('bad')).toBe(false)
+  })
+})
+
+describe('resolveTorrentHashes', () => {
+  it('expands hashes=all from download queue', async () => {
+    const amule = {
+      getDownloadQueue: vi.fn(async () => [
+        { fileHash: ED2K },
+        { fileHash: undefined },
+      ]),
+    }
+
+    const hashes = await resolveTorrentHashes(amule as never, 'all')
+    expect(hashes).toEqual([ED2K])
+  })
+
+  it('filters invalid pipe-separated hashes', async () => {
+    const amule = { getDownloadQueue: vi.fn() }
+    const hashes = await resolveTorrentHashes(amule as never, `${ED2K}|bad|`)
+    expect(hashes).toEqual([ED2K])
+  })
+})

--- a/src/amulerr/src/lib/torrents.ts
+++ b/src/amulerr/src/lib/torrents.ts
@@ -1,0 +1,64 @@
+import type AmuleClient from '#/amule-ec-node/AmuleClient.mjs'
+import { normalizeEd2kHash, sameEd2kHash } from './links'
+import { skipFalsy } from './array'
+
+export { normalizeEd2kHash, sameEd2kHash }
+
+export function parseTorrentHash(
+  rawHash: string | null | undefined,
+): string | null {
+  return normalizeEd2kHash(rawHash)
+}
+
+export function hasTorrentHashInput(
+  rawHashes: string | null | undefined,
+): boolean {
+  const value = rawHashes?.toString().trim()
+  if (!value) {
+    return false
+  }
+
+  if (value.toLowerCase() === 'all') {
+    return true
+  }
+
+  return value
+    .split('|')
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .some((part) => normalizeEd2kHash(part) !== null)
+}
+
+export function ed2kHashSet(hashes: string[]): Set<string> {
+  return new Set(
+    hashes.flatMap((hash) => {
+      const normalized = normalizeEd2kHash(hash)
+      return normalized ? [normalized] : []
+    }),
+  )
+}
+
+export async function resolveTorrentHashes(
+  amule: AmuleClient,
+  rawHashes: string | null | undefined,
+): Promise<string[]> {
+  const value = rawHashes?.toString().trim()
+  if (!value) {
+    return []
+  }
+
+  if (value.toLowerCase() === 'all') {
+    const downloads = await amule.getDownloadQueue()
+    return downloads
+      .map((d) => d.fileHash)
+      .filter((h): h is string => !!h)
+      .map((h) => normalizeEd2kHash(h))
+      .filter((h): h is string => !!h)
+  }
+
+  return value
+    .split('|')
+    .filter(skipFalsy)
+    .map((h) => normalizeEd2kHash(h))
+    .filter((h): h is string => !!h)
+}

--- a/src/amulerr/src/routeTree.gen.ts
+++ b/src/amulerr/src/routeTree.gen.ts
@@ -12,20 +12,28 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as HealthRouteImport } from './routes/health'
 import { Route as ApiRouteImport } from './routes/api'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as ApiV2TorrentsTopPrioRouteImport } from './routes/api.v2.torrents.topPrio'
 import { Route as ApiV2TorrentsStopRouteImport } from './routes/api.v2.torrents.stop'
 import { Route as ApiV2TorrentsStartRouteImport } from './routes/api.v2.torrents.start'
+import { Route as ApiV2TorrentsSetShareLimitsRouteImport } from './routes/api.v2.torrents.setShareLimits'
+import { Route as ApiV2TorrentsSetForceStartRouteImport } from './routes/api.v2.torrents.setForceStart'
 import { Route as ApiV2TorrentsSetCategoryRouteImport } from './routes/api.v2.torrents.setCategory'
 import { Route as ApiV2TorrentsResumeRouteImport } from './routes/api.v2.torrents.resume'
+import { Route as ApiV2TorrentsPropertiesRouteImport } from './routes/api.v2.torrents.properties'
 import { Route as ApiV2TorrentsPauseRouteImport } from './routes/api.v2.torrents.pause'
 import { Route as ApiV2TorrentsInfoRouteImport } from './routes/api.v2.torrents.info'
 import { Route as ApiV2TorrentsFilesRouteImport } from './routes/api.v2.torrents.files'
 import { Route as ApiV2TorrentsDeleteCategoryRouteImport } from './routes/api.v2.torrents.deleteCategory'
 import { Route as ApiV2TorrentsDeleteRouteImport } from './routes/api.v2.torrents.delete'
 import { Route as ApiV2TorrentsCreateCategoryRouteImport } from './routes/api.v2.torrents.createCategory'
+import { Route as ApiV2TorrentsContentsRouteImport } from './routes/api.v2.torrents.contents'
 import { Route as ApiV2TorrentsCategoriesRouteImport } from './routes/api.v2.torrents.categories'
 import { Route as ApiV2TorrentsAddRouteImport } from './routes/api.v2.torrents.add'
 import { Route as ApiV2SyncMaindataRouteImport } from './routes/api.v2.sync.maindata'
+import { Route as ApiV2AuthLogoutRouteImport } from './routes/api.v2.auth.logout'
+import { Route as ApiV2AuthLoginRouteImport } from './routes/api.v2.auth.login'
 import { Route as ApiV2AppWebapiVersionRouteImport } from './routes/api.v2.app.webapiVersion'
+import { Route as ApiV2AppVersionRouteImport } from './routes/api.v2.app.version'
 import { Route as ApiV2AppPreferencesRouteImport } from './routes/api.v2.app.preferences'
 
 const HealthRoute = HealthRouteImport.update({
@@ -43,6 +51,11 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiV2TorrentsTopPrioRoute = ApiV2TorrentsTopPrioRouteImport.update({
+  id: '/v2/torrents/topPrio',
+  path: '/v2/torrents/topPrio',
+  getParentRoute: () => ApiRoute,
+} as any)
 const ApiV2TorrentsStopRoute = ApiV2TorrentsStopRouteImport.update({
   id: '/v2/torrents/stop',
   path: '/v2/torrents/stop',
@@ -53,6 +66,18 @@ const ApiV2TorrentsStartRoute = ApiV2TorrentsStartRouteImport.update({
   path: '/v2/torrents/start',
   getParentRoute: () => ApiRoute,
 } as any)
+const ApiV2TorrentsSetShareLimitsRoute =
+  ApiV2TorrentsSetShareLimitsRouteImport.update({
+    id: '/v2/torrents/setShareLimits',
+    path: '/v2/torrents/setShareLimits',
+    getParentRoute: () => ApiRoute,
+  } as any)
+const ApiV2TorrentsSetForceStartRoute =
+  ApiV2TorrentsSetForceStartRouteImport.update({
+    id: '/v2/torrents/setForceStart',
+    path: '/v2/torrents/setForceStart',
+    getParentRoute: () => ApiRoute,
+  } as any)
 const ApiV2TorrentsSetCategoryRoute =
   ApiV2TorrentsSetCategoryRouteImport.update({
     id: '/v2/torrents/setCategory',
@@ -62,6 +87,11 @@ const ApiV2TorrentsSetCategoryRoute =
 const ApiV2TorrentsResumeRoute = ApiV2TorrentsResumeRouteImport.update({
   id: '/v2/torrents/resume',
   path: '/v2/torrents/resume',
+  getParentRoute: () => ApiRoute,
+} as any)
+const ApiV2TorrentsPropertiesRoute = ApiV2TorrentsPropertiesRouteImport.update({
+  id: '/v2/torrents/properties',
+  path: '/v2/torrents/properties',
   getParentRoute: () => ApiRoute,
 } as any)
 const ApiV2TorrentsPauseRoute = ApiV2TorrentsPauseRouteImport.update({
@@ -96,6 +126,11 @@ const ApiV2TorrentsCreateCategoryRoute =
     path: '/v2/torrents/createCategory',
     getParentRoute: () => ApiRoute,
   } as any)
+const ApiV2TorrentsContentsRoute = ApiV2TorrentsContentsRouteImport.update({
+  id: '/v2/torrents/contents',
+  path: '/v2/torrents/contents',
+  getParentRoute: () => ApiRoute,
+} as any)
 const ApiV2TorrentsCategoriesRoute = ApiV2TorrentsCategoriesRouteImport.update({
   id: '/v2/torrents/categories',
   path: '/v2/torrents/categories',
@@ -111,9 +146,24 @@ const ApiV2SyncMaindataRoute = ApiV2SyncMaindataRouteImport.update({
   path: '/v2/sync/maindata',
   getParentRoute: () => ApiRoute,
 } as any)
+const ApiV2AuthLogoutRoute = ApiV2AuthLogoutRouteImport.update({
+  id: '/v2/auth/logout',
+  path: '/v2/auth/logout',
+  getParentRoute: () => ApiRoute,
+} as any)
+const ApiV2AuthLoginRoute = ApiV2AuthLoginRouteImport.update({
+  id: '/v2/auth/login',
+  path: '/v2/auth/login',
+  getParentRoute: () => ApiRoute,
+} as any)
 const ApiV2AppWebapiVersionRoute = ApiV2AppWebapiVersionRouteImport.update({
   id: '/v2/app/webapiVersion',
   path: '/v2/app/webapiVersion',
+  getParentRoute: () => ApiRoute,
+} as any)
+const ApiV2AppVersionRoute = ApiV2AppVersionRouteImport.update({
+  id: '/v2/app/version',
+  path: '/v2/app/version',
   getParentRoute: () => ApiRoute,
 } as any)
 const ApiV2AppPreferencesRoute = ApiV2AppPreferencesRouteImport.update({
@@ -127,40 +177,56 @@ export interface FileRoutesByFullPath {
   '/api': typeof ApiRouteWithChildren
   '/health': typeof HealthRoute
   '/api/v2/app/preferences': typeof ApiV2AppPreferencesRoute
+  '/api/v2/app/version': typeof ApiV2AppVersionRoute
   '/api/v2/app/webapiVersion': typeof ApiV2AppWebapiVersionRoute
+  '/api/v2/auth/login': typeof ApiV2AuthLoginRoute
+  '/api/v2/auth/logout': typeof ApiV2AuthLogoutRoute
   '/api/v2/sync/maindata': typeof ApiV2SyncMaindataRoute
   '/api/v2/torrents/add': typeof ApiV2TorrentsAddRoute
   '/api/v2/torrents/categories': typeof ApiV2TorrentsCategoriesRoute
+  '/api/v2/torrents/contents': typeof ApiV2TorrentsContentsRoute
   '/api/v2/torrents/createCategory': typeof ApiV2TorrentsCreateCategoryRoute
   '/api/v2/torrents/delete': typeof ApiV2TorrentsDeleteRoute
   '/api/v2/torrents/deleteCategory': typeof ApiV2TorrentsDeleteCategoryRoute
   '/api/v2/torrents/files': typeof ApiV2TorrentsFilesRoute
   '/api/v2/torrents/info': typeof ApiV2TorrentsInfoRoute
   '/api/v2/torrents/pause': typeof ApiV2TorrentsPauseRoute
+  '/api/v2/torrents/properties': typeof ApiV2TorrentsPropertiesRoute
   '/api/v2/torrents/resume': typeof ApiV2TorrentsResumeRoute
   '/api/v2/torrents/setCategory': typeof ApiV2TorrentsSetCategoryRoute
+  '/api/v2/torrents/setForceStart': typeof ApiV2TorrentsSetForceStartRoute
+  '/api/v2/torrents/setShareLimits': typeof ApiV2TorrentsSetShareLimitsRoute
   '/api/v2/torrents/start': typeof ApiV2TorrentsStartRoute
   '/api/v2/torrents/stop': typeof ApiV2TorrentsStopRoute
+  '/api/v2/torrents/topPrio': typeof ApiV2TorrentsTopPrioRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/api': typeof ApiRouteWithChildren
   '/health': typeof HealthRoute
   '/api/v2/app/preferences': typeof ApiV2AppPreferencesRoute
+  '/api/v2/app/version': typeof ApiV2AppVersionRoute
   '/api/v2/app/webapiVersion': typeof ApiV2AppWebapiVersionRoute
+  '/api/v2/auth/login': typeof ApiV2AuthLoginRoute
+  '/api/v2/auth/logout': typeof ApiV2AuthLogoutRoute
   '/api/v2/sync/maindata': typeof ApiV2SyncMaindataRoute
   '/api/v2/torrents/add': typeof ApiV2TorrentsAddRoute
   '/api/v2/torrents/categories': typeof ApiV2TorrentsCategoriesRoute
+  '/api/v2/torrents/contents': typeof ApiV2TorrentsContentsRoute
   '/api/v2/torrents/createCategory': typeof ApiV2TorrentsCreateCategoryRoute
   '/api/v2/torrents/delete': typeof ApiV2TorrentsDeleteRoute
   '/api/v2/torrents/deleteCategory': typeof ApiV2TorrentsDeleteCategoryRoute
   '/api/v2/torrents/files': typeof ApiV2TorrentsFilesRoute
   '/api/v2/torrents/info': typeof ApiV2TorrentsInfoRoute
   '/api/v2/torrents/pause': typeof ApiV2TorrentsPauseRoute
+  '/api/v2/torrents/properties': typeof ApiV2TorrentsPropertiesRoute
   '/api/v2/torrents/resume': typeof ApiV2TorrentsResumeRoute
   '/api/v2/torrents/setCategory': typeof ApiV2TorrentsSetCategoryRoute
+  '/api/v2/torrents/setForceStart': typeof ApiV2TorrentsSetForceStartRoute
+  '/api/v2/torrents/setShareLimits': typeof ApiV2TorrentsSetShareLimitsRoute
   '/api/v2/torrents/start': typeof ApiV2TorrentsStartRoute
   '/api/v2/torrents/stop': typeof ApiV2TorrentsStopRoute
+  '/api/v2/torrents/topPrio': typeof ApiV2TorrentsTopPrioRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -168,20 +234,28 @@ export interface FileRoutesById {
   '/api': typeof ApiRouteWithChildren
   '/health': typeof HealthRoute
   '/api/v2/app/preferences': typeof ApiV2AppPreferencesRoute
+  '/api/v2/app/version': typeof ApiV2AppVersionRoute
   '/api/v2/app/webapiVersion': typeof ApiV2AppWebapiVersionRoute
+  '/api/v2/auth/login': typeof ApiV2AuthLoginRoute
+  '/api/v2/auth/logout': typeof ApiV2AuthLogoutRoute
   '/api/v2/sync/maindata': typeof ApiV2SyncMaindataRoute
   '/api/v2/torrents/add': typeof ApiV2TorrentsAddRoute
   '/api/v2/torrents/categories': typeof ApiV2TorrentsCategoriesRoute
+  '/api/v2/torrents/contents': typeof ApiV2TorrentsContentsRoute
   '/api/v2/torrents/createCategory': typeof ApiV2TorrentsCreateCategoryRoute
   '/api/v2/torrents/delete': typeof ApiV2TorrentsDeleteRoute
   '/api/v2/torrents/deleteCategory': typeof ApiV2TorrentsDeleteCategoryRoute
   '/api/v2/torrents/files': typeof ApiV2TorrentsFilesRoute
   '/api/v2/torrents/info': typeof ApiV2TorrentsInfoRoute
   '/api/v2/torrents/pause': typeof ApiV2TorrentsPauseRoute
+  '/api/v2/torrents/properties': typeof ApiV2TorrentsPropertiesRoute
   '/api/v2/torrents/resume': typeof ApiV2TorrentsResumeRoute
   '/api/v2/torrents/setCategory': typeof ApiV2TorrentsSetCategoryRoute
+  '/api/v2/torrents/setForceStart': typeof ApiV2TorrentsSetForceStartRoute
+  '/api/v2/torrents/setShareLimits': typeof ApiV2TorrentsSetShareLimitsRoute
   '/api/v2/torrents/start': typeof ApiV2TorrentsStartRoute
   '/api/v2/torrents/stop': typeof ApiV2TorrentsStopRoute
+  '/api/v2/torrents/topPrio': typeof ApiV2TorrentsTopPrioRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -190,60 +264,84 @@ export interface FileRouteTypes {
     | '/api'
     | '/health'
     | '/api/v2/app/preferences'
+    | '/api/v2/app/version'
     | '/api/v2/app/webapiVersion'
+    | '/api/v2/auth/login'
+    | '/api/v2/auth/logout'
     | '/api/v2/sync/maindata'
     | '/api/v2/torrents/add'
     | '/api/v2/torrents/categories'
+    | '/api/v2/torrents/contents'
     | '/api/v2/torrents/createCategory'
     | '/api/v2/torrents/delete'
     | '/api/v2/torrents/deleteCategory'
     | '/api/v2/torrents/files'
     | '/api/v2/torrents/info'
     | '/api/v2/torrents/pause'
+    | '/api/v2/torrents/properties'
     | '/api/v2/torrents/resume'
     | '/api/v2/torrents/setCategory'
+    | '/api/v2/torrents/setForceStart'
+    | '/api/v2/torrents/setShareLimits'
     | '/api/v2/torrents/start'
     | '/api/v2/torrents/stop'
+    | '/api/v2/torrents/topPrio'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/api'
     | '/health'
     | '/api/v2/app/preferences'
+    | '/api/v2/app/version'
     | '/api/v2/app/webapiVersion'
+    | '/api/v2/auth/login'
+    | '/api/v2/auth/logout'
     | '/api/v2/sync/maindata'
     | '/api/v2/torrents/add'
     | '/api/v2/torrents/categories'
+    | '/api/v2/torrents/contents'
     | '/api/v2/torrents/createCategory'
     | '/api/v2/torrents/delete'
     | '/api/v2/torrents/deleteCategory'
     | '/api/v2/torrents/files'
     | '/api/v2/torrents/info'
     | '/api/v2/torrents/pause'
+    | '/api/v2/torrents/properties'
     | '/api/v2/torrents/resume'
     | '/api/v2/torrents/setCategory'
+    | '/api/v2/torrents/setForceStart'
+    | '/api/v2/torrents/setShareLimits'
     | '/api/v2/torrents/start'
     | '/api/v2/torrents/stop'
+    | '/api/v2/torrents/topPrio'
   id:
     | '__root__'
     | '/'
     | '/api'
     | '/health'
     | '/api/v2/app/preferences'
+    | '/api/v2/app/version'
     | '/api/v2/app/webapiVersion'
+    | '/api/v2/auth/login'
+    | '/api/v2/auth/logout'
     | '/api/v2/sync/maindata'
     | '/api/v2/torrents/add'
     | '/api/v2/torrents/categories'
+    | '/api/v2/torrents/contents'
     | '/api/v2/torrents/createCategory'
     | '/api/v2/torrents/delete'
     | '/api/v2/torrents/deleteCategory'
     | '/api/v2/torrents/files'
     | '/api/v2/torrents/info'
     | '/api/v2/torrents/pause'
+    | '/api/v2/torrents/properties'
     | '/api/v2/torrents/resume'
     | '/api/v2/torrents/setCategory'
+    | '/api/v2/torrents/setForceStart'
+    | '/api/v2/torrents/setShareLimits'
     | '/api/v2/torrents/start'
     | '/api/v2/torrents/stop'
+    | '/api/v2/torrents/topPrio'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -275,6 +373,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/v2/torrents/topPrio': {
+      id: '/api/v2/torrents/topPrio'
+      path: '/v2/torrents/topPrio'
+      fullPath: '/api/v2/torrents/topPrio'
+      preLoaderRoute: typeof ApiV2TorrentsTopPrioRouteImport
+      parentRoute: typeof ApiRoute
+    }
     '/api/v2/torrents/stop': {
       id: '/api/v2/torrents/stop'
       path: '/v2/torrents/stop'
@@ -289,6 +394,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV2TorrentsStartRouteImport
       parentRoute: typeof ApiRoute
     }
+    '/api/v2/torrents/setShareLimits': {
+      id: '/api/v2/torrents/setShareLimits'
+      path: '/v2/torrents/setShareLimits'
+      fullPath: '/api/v2/torrents/setShareLimits'
+      preLoaderRoute: typeof ApiV2TorrentsSetShareLimitsRouteImport
+      parentRoute: typeof ApiRoute
+    }
+    '/api/v2/torrents/setForceStart': {
+      id: '/api/v2/torrents/setForceStart'
+      path: '/v2/torrents/setForceStart'
+      fullPath: '/api/v2/torrents/setForceStart'
+      preLoaderRoute: typeof ApiV2TorrentsSetForceStartRouteImport
+      parentRoute: typeof ApiRoute
+    }
     '/api/v2/torrents/setCategory': {
       id: '/api/v2/torrents/setCategory'
       path: '/v2/torrents/setCategory'
@@ -301,6 +420,13 @@ declare module '@tanstack/react-router' {
       path: '/v2/torrents/resume'
       fullPath: '/api/v2/torrents/resume'
       preLoaderRoute: typeof ApiV2TorrentsResumeRouteImport
+      parentRoute: typeof ApiRoute
+    }
+    '/api/v2/torrents/properties': {
+      id: '/api/v2/torrents/properties'
+      path: '/v2/torrents/properties'
+      fullPath: '/api/v2/torrents/properties'
+      preLoaderRoute: typeof ApiV2TorrentsPropertiesRouteImport
       parentRoute: typeof ApiRoute
     }
     '/api/v2/torrents/pause': {
@@ -345,6 +471,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV2TorrentsCreateCategoryRouteImport
       parentRoute: typeof ApiRoute
     }
+    '/api/v2/torrents/contents': {
+      id: '/api/v2/torrents/contents'
+      path: '/v2/torrents/contents'
+      fullPath: '/api/v2/torrents/contents'
+      preLoaderRoute: typeof ApiV2TorrentsContentsRouteImport
+      parentRoute: typeof ApiRoute
+    }
     '/api/v2/torrents/categories': {
       id: '/api/v2/torrents/categories'
       path: '/v2/torrents/categories'
@@ -366,11 +499,32 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV2SyncMaindataRouteImport
       parentRoute: typeof ApiRoute
     }
+    '/api/v2/auth/logout': {
+      id: '/api/v2/auth/logout'
+      path: '/v2/auth/logout'
+      fullPath: '/api/v2/auth/logout'
+      preLoaderRoute: typeof ApiV2AuthLogoutRouteImport
+      parentRoute: typeof ApiRoute
+    }
+    '/api/v2/auth/login': {
+      id: '/api/v2/auth/login'
+      path: '/v2/auth/login'
+      fullPath: '/api/v2/auth/login'
+      preLoaderRoute: typeof ApiV2AuthLoginRouteImport
+      parentRoute: typeof ApiRoute
+    }
     '/api/v2/app/webapiVersion': {
       id: '/api/v2/app/webapiVersion'
       path: '/v2/app/webapiVersion'
       fullPath: '/api/v2/app/webapiVersion'
       preLoaderRoute: typeof ApiV2AppWebapiVersionRouteImport
+      parentRoute: typeof ApiRoute
+    }
+    '/api/v2/app/version': {
+      id: '/api/v2/app/version'
+      path: '/v2/app/version'
+      fullPath: '/api/v2/app/version'
+      preLoaderRoute: typeof ApiV2AppVersionRouteImport
       parentRoute: typeof ApiRoute
     }
     '/api/v2/app/preferences': {
@@ -385,38 +539,54 @@ declare module '@tanstack/react-router' {
 
 interface ApiRouteChildren {
   ApiV2AppPreferencesRoute: typeof ApiV2AppPreferencesRoute
+  ApiV2AppVersionRoute: typeof ApiV2AppVersionRoute
   ApiV2AppWebapiVersionRoute: typeof ApiV2AppWebapiVersionRoute
+  ApiV2AuthLoginRoute: typeof ApiV2AuthLoginRoute
+  ApiV2AuthLogoutRoute: typeof ApiV2AuthLogoutRoute
   ApiV2SyncMaindataRoute: typeof ApiV2SyncMaindataRoute
   ApiV2TorrentsAddRoute: typeof ApiV2TorrentsAddRoute
   ApiV2TorrentsCategoriesRoute: typeof ApiV2TorrentsCategoriesRoute
+  ApiV2TorrentsContentsRoute: typeof ApiV2TorrentsContentsRoute
   ApiV2TorrentsCreateCategoryRoute: typeof ApiV2TorrentsCreateCategoryRoute
   ApiV2TorrentsDeleteRoute: typeof ApiV2TorrentsDeleteRoute
   ApiV2TorrentsDeleteCategoryRoute: typeof ApiV2TorrentsDeleteCategoryRoute
   ApiV2TorrentsFilesRoute: typeof ApiV2TorrentsFilesRoute
   ApiV2TorrentsInfoRoute: typeof ApiV2TorrentsInfoRoute
   ApiV2TorrentsPauseRoute: typeof ApiV2TorrentsPauseRoute
+  ApiV2TorrentsPropertiesRoute: typeof ApiV2TorrentsPropertiesRoute
   ApiV2TorrentsResumeRoute: typeof ApiV2TorrentsResumeRoute
   ApiV2TorrentsSetCategoryRoute: typeof ApiV2TorrentsSetCategoryRoute
+  ApiV2TorrentsSetForceStartRoute: typeof ApiV2TorrentsSetForceStartRoute
+  ApiV2TorrentsSetShareLimitsRoute: typeof ApiV2TorrentsSetShareLimitsRoute
   ApiV2TorrentsStartRoute: typeof ApiV2TorrentsStartRoute
   ApiV2TorrentsStopRoute: typeof ApiV2TorrentsStopRoute
+  ApiV2TorrentsTopPrioRoute: typeof ApiV2TorrentsTopPrioRoute
 }
 
 const ApiRouteChildren: ApiRouteChildren = {
   ApiV2AppPreferencesRoute: ApiV2AppPreferencesRoute,
+  ApiV2AppVersionRoute: ApiV2AppVersionRoute,
   ApiV2AppWebapiVersionRoute: ApiV2AppWebapiVersionRoute,
+  ApiV2AuthLoginRoute: ApiV2AuthLoginRoute,
+  ApiV2AuthLogoutRoute: ApiV2AuthLogoutRoute,
   ApiV2SyncMaindataRoute: ApiV2SyncMaindataRoute,
   ApiV2TorrentsAddRoute: ApiV2TorrentsAddRoute,
   ApiV2TorrentsCategoriesRoute: ApiV2TorrentsCategoriesRoute,
+  ApiV2TorrentsContentsRoute: ApiV2TorrentsContentsRoute,
   ApiV2TorrentsCreateCategoryRoute: ApiV2TorrentsCreateCategoryRoute,
   ApiV2TorrentsDeleteRoute: ApiV2TorrentsDeleteRoute,
   ApiV2TorrentsDeleteCategoryRoute: ApiV2TorrentsDeleteCategoryRoute,
   ApiV2TorrentsFilesRoute: ApiV2TorrentsFilesRoute,
   ApiV2TorrentsInfoRoute: ApiV2TorrentsInfoRoute,
   ApiV2TorrentsPauseRoute: ApiV2TorrentsPauseRoute,
+  ApiV2TorrentsPropertiesRoute: ApiV2TorrentsPropertiesRoute,
   ApiV2TorrentsResumeRoute: ApiV2TorrentsResumeRoute,
   ApiV2TorrentsSetCategoryRoute: ApiV2TorrentsSetCategoryRoute,
+  ApiV2TorrentsSetForceStartRoute: ApiV2TorrentsSetForceStartRoute,
+  ApiV2TorrentsSetShareLimitsRoute: ApiV2TorrentsSetShareLimitsRoute,
   ApiV2TorrentsStartRoute: ApiV2TorrentsStartRoute,
   ApiV2TorrentsStopRoute: ApiV2TorrentsStopRoute,
+  ApiV2TorrentsTopPrioRoute: ApiV2TorrentsTopPrioRoute,
 }
 
 const ApiRouteWithChildren = ApiRoute._addFileChildren(ApiRouteChildren)

--- a/src/amulerr/src/routes/api.v2.app.preferences.tsx
+++ b/src/amulerr/src/routes/api.v2.app.preferences.tsx
@@ -1,21 +1,10 @@
-
+import { defaultQbittorrentPreferences } from '#/lib/qbittorrent'
 import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/api/v2/app/preferences')({
   server: {
     handlers: {
-      GET: async () => {
-        return Response.json({
-          save_path: "/downloads/complete",
-          temp_path_enabled: true,
-          temp_path: "/downloads/incomplete",
-          create_subfolder_enabled: false,
-          max_ratio_enabled: true,
-          max_ratio: 0,
-          max_seeding_time_enabled: true,
-          max_seeding_time: 0,
-        });
-      },
+      GET: async () => Response.json(defaultQbittorrentPreferences()),
     },
   },
 })

--- a/src/amulerr/src/routes/api.v2.app.version.tsx
+++ b/src/amulerr/src/routes/api.v2.app.version.tsx
@@ -1,0 +1,13 @@
+import {
+  QBITTORRENT_APP_VERSION,
+  qbittorrentPlainTextResponse,
+} from '#/lib/qbittorrent'
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/api/v2/app/version')({
+  server: {
+    handlers: {
+      GET: async () => qbittorrentPlainTextResponse(QBITTORRENT_APP_VERSION),
+    },
+  },
+})

--- a/src/amulerr/src/routes/api.v2.app.webapiVersion.tsx
+++ b/src/amulerr/src/routes/api.v2.app.webapiVersion.tsx
@@ -1,19 +1,13 @@
-
+import {
+  QBITTORRENT_WEBAPI_VERSION,
+  qbittorrentPlainTextResponse,
+} from '#/lib/qbittorrent'
 import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/api/v2/app/webapiVersion')({
   server: {
     handlers: {
-      GET: async () => {
-        return new Response(`2.8.19`, {
-          status: 200,
-          headers: {
-            "Content-Type": "text",
-            "X-Content-Type-Options": "nosniff",
-            "Cache-Control": "public, max-age=0",
-          },
-        })
-      }
-    }
+      GET: async () => qbittorrentPlainTextResponse(QBITTORRENT_WEBAPI_VERSION),
+    },
   },
 })

--- a/src/amulerr/src/routes/api.v2.auth.login.tsx
+++ b/src/amulerr/src/routes/api.v2.auth.login.tsx
@@ -1,0 +1,27 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { secureCookieSuffix } from '#/lib/cookies'
+
+// amulerr does not implement authentication. We still return qBittorrent's standard
+// response ("Ok." + SID cookie) so that clients requiring the /api/v2/auth/login step
+// (Prowlarr, Sonarr, Radarr, Medusa, ...) accept the connection.
+const ok = (request: Request) => {
+  const secure = secureCookieSuffix(request)
+  return new Response(`Ok.`, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/plain',
+      'X-Content-Type-Options': 'nosniff',
+      'Set-Cookie': `SID=amulerr; HttpOnly; SameSite=Strict; Path=/${secure}`,
+      'Cache-Control': 'no-store',
+    },
+  })
+}
+
+export const Route = createFileRoute('/api/v2/auth/login')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => ok(request),
+      GET: async ({ request }) => ok(request),
+    },
+  },
+})

--- a/src/amulerr/src/routes/api.v2.auth.logout.tsx
+++ b/src/amulerr/src/routes/api.v2.auth.logout.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { secureCookieSuffix } from '#/lib/cookies'
+
+const ok = (request: Request) => {
+  const secure = secureCookieSuffix(request)
+  return new Response(`Ok.`, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/plain',
+      'X-Content-Type-Options': 'nosniff',
+      'Set-Cookie': `SID=; HttpOnly; SameSite=Strict; Path=/; Max-Age=0${secure}`,
+      'Cache-Control': 'no-store',
+    },
+  })
+}
+
+export const Route = createFileRoute('/api/v2/auth/logout')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => ok(request),
+      GET: async ({ request }) => ok(request),
+    },
+  },
+})

--- a/src/amulerr/src/routes/api.v2.torrents.add.tsx
+++ b/src/amulerr/src/routes/api.v2.torrents.add.tsx
@@ -1,40 +1,92 @@
 import { useAmule } from '#/amule'
-import { fromMagnetLink, toEd2kLink } from '#/lib/links'
+import { fromMagnetLink, sameEd2kHash, toEd2kLink } from '#/lib/links'
 import { createFileRoute } from '@tanstack/react-router'
+
+function addError(message: string, status = 400) {
+  return new Response(message, {
+    status,
+    headers: {
+      'Content-Type': 'text/plain',
+      'X-Content-Type-Options': 'nosniff',
+      'Cache-Control': 'no-store',
+    },
+  })
+}
 
 export const Route = createFileRoute('/api/v2/torrents/add')({
   server: {
     handlers: {
       POST: async ({ request }) => {
         const formData = await request.formData()
-        const urls = formData.get("urls")?.toString()
-        const category = formData.get("category")?.toString()
+        const urls = (formData.get('urls') ?? '').toString().trim()
+        const category = (formData.get('category') ?? '').toString().trim()
+
+        // qBittorrent clients also send savepath, paused/stopped, ratioLimit, seedingTimeLimit,
+        // sequentialDownload, firstLastPiecePrio, contentLayout — all ignored (no aMule equivalent).
 
         if (!urls) {
-          throw new Error("No URL to download")
+          return addError('Missing urls parameter')
         }
 
         if (!category) {
-          throw new Error("No download category")
+          return addError('Missing category parameter')
         }
 
-        const { hash, name, size } = fromMagnetLink(urls)
+        let hash: string
+        let name: string
+        let size: number
+        try {
+          ;({ hash, name, size } = fromMagnetLink(urls))
+        } catch {
+          return addError('Invalid magnet link')
+        }
+
         const ed2kLink = toEd2kLink(hash, name, size)
 
-        await useAmule(async (amule) => {
-          const categories = await amule.getCategories()
-          const categoryId = categories.find(c => c.title === category)?.id
-          if (!categoryId) {
-            throw new Error(`Category ${category} not found`)
+        const addResult = await useAmule(async (amule) => {
+          const isPresent = async () => {
+            const downloads = await amule.getDownloadQueue()
+            const shared = await amule.getSharedFiles()
+            return [...downloads, ...shared].some((f) =>
+              sameEd2kHash(f.fileHash, hash),
+            )
           }
 
-          if (!await amule.addEd2kLink(ed2kLink, categoryId)) {
-            throw new Error(`Failed to add torrent ${ed2kLink}`)
+          // Idempotent like qBittorrent: aMule rejects duplicates, which clients read as a failed add.
+          if (await isPresent()) {
+            return { ok: true as const }
           }
+
+          const categories = await amule.getCategories()
+          const categoryId = categories.find((c) => c.title === category)?.id
+          if (!categoryId) {
+            return {
+              ok: false as const,
+              error: `Category ${category} not found`,
+              status: 404,
+            }
+          }
+
+          if (
+            !(await amule.addEd2kLink(ed2kLink, categoryId)) &&
+            !(await isPresent())
+          ) {
+            return {
+              ok: false as const,
+              error: `Failed to add torrent`,
+              status: 500,
+            }
+          }
+
+          return { ok: true as const }
         })
+
+        if (!addResult.ok) {
+          return addError(addResult.error, addResult.status)
+        }
 
         return Response.json({})
       },
-    }
-  }
+    },
+  },
 })

--- a/src/amulerr/src/routes/api.v2.torrents.contents.tsx
+++ b/src/amulerr/src/routes/api.v2.torrents.contents.tsx
@@ -4,10 +4,14 @@ import {
 } from '#/lib/torrent-files'
 import { createFileRoute } from '@tanstack/react-router'
 
-// https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-contents
-export const Route = createFileRoute('/api/v2/torrents/files')({
+// PyMedusa posts here (legacy qBittorrent name); same payload as GET /torrents/files.
+export const Route = createFileRoute('/api/v2/torrents/contents')({
   server: {
     handlers: {
+      POST: async ({ request }) => {
+        const rawHash = await extractTorrentHash(request)
+        return getTorrentFilesResponse(rawHash)
+      },
       GET: async ({ request }) => {
         const rawHash = await extractTorrentHash(request)
         return getTorrentFilesResponse(rawHash)

--- a/src/amulerr/src/routes/api.v2.torrents.delete.tsx
+++ b/src/amulerr/src/routes/api.v2.torrents.delete.tsx
@@ -1,5 +1,11 @@
 import { useAmule } from '#/amule'
 import { skipFalsy } from '#/lib/array'
+import {
+  ed2kHashSet,
+  hasTorrentHashInput,
+  normalizeEd2kHash,
+  resolveTorrentHashes,
+} from '#/lib/torrents'
 import { createFileRoute } from '@tanstack/react-router'
 import fs from 'node:fs/promises'
 import path from 'node:path'
@@ -9,26 +15,32 @@ export const Route = createFileRoute('/api/v2/torrents/delete')({
     handlers: {
       POST: async ({ request }) => {
         const formData = await request.formData()
-        const hashes = formData
-          .get('hashes')
-          ?.toString()
-          ?.toUpperCase()
-          ?.split('|')
-          .filter(skipFalsy)
+        const rawHashes = formData.get('hashes')?.toString()
 
         const deleteFilesQsp = formData.get('deleteFiles')?.toString()
-        const deleteFiles = !deleteFilesQsp || deleteFilesQsp.toLowerCase() === 'true'
+        const deleteFiles =
+          !deleteFilesQsp || deleteFilesQsp.toLowerCase() === 'true'
 
-        if (hashes?.length) {
+        if (hasTorrentHashInput(rawHashes)) {
           await useAmule(async (amule) => {
+            const allHashes = rawHashes?.trim().toLowerCase() === 'all'
+            const hashes = await resolveTorrentHashes(amule, rawHashes)
+            if (!hashes.length && !allHashes) {
+              return
+            }
+
             const shared = await amule.getSharedFiles()
-            const matches = shared.filter(
-              (f) => f.fileHash && hashes.includes(f.fileHash.toUpperCase()),
-            )
+            const hashSet = ed2kHashSet(hashes)
+            const matches = shared.filter((f) => {
+              if (allHashes) {
+                return true
+              }
+              const normalized = normalizeEd2kHash(f.fileHash)
+              return normalized !== null && hashSet.has(normalized)
+            })
 
             const ecids = matches.map((f) => f.ecid).filter(skipFalsy)
             await amule.clearCompleted(ecids)
-
             for (const hash of hashes) {
               await amule.cancelDownload(hash)
             }

--- a/src/amulerr/src/routes/api.v2.torrents.info.tsx
+++ b/src/amulerr/src/routes/api.v2.torrents.info.tsx
@@ -1,6 +1,12 @@
-
 import { useAmule } from '#/amule'
 import type { DownloadItem } from '#/amule-ec-node/AmuleClient.mjs'
+import { normalizeEd2kHash, toQbittorrentHash } from '#/lib/links'
+import {
+  clampProgress,
+  qbittorrentTorrentExtras,
+  torrentAmountLeft,
+  torrentEta,
+} from '#/lib/qbittorrent'
 import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/api/v2/torrents/info')({
@@ -8,82 +14,116 @@ export const Route = createFileRoute('/api/v2/torrents/info')({
     handlers: {
       GET: async ({ request }) => {
         const url = new URL(request.url)
-        const categoryTitle = url.searchParams.get("category")
+        const categoryTitle = url.searchParams.get('category')
 
-        const { categories, shared, downloads } = await useAmule(async (amule) => {
-          const categories = await amule.getCategories()
-          const downloads = await amule.getDownloadQueue()
-          const shared = await amule.getSharedFiles()
+        const { categories, shared, downloads } = await useAmule(
+          async (amule) => {
+            const categories = await amule.getCategories()
+            const downloads = await amule.getDownloadQueue()
+            const shared = await amule.getSharedFiles()
 
-          return {
-            categories,
-            downloads: downloads.map(d => ({ ...d, category_obj: categories.find(c => c.id === d.category) })),
-            shared: shared
-              .filter(s => !downloads.some(d => d.fileHash === s.fileHash))
-              .map(d => ({ ...d, category_obj: categories.find(c => c.path === d.path) })),
-          }
-        })
+            const downloadHashes = new Set(
+              downloads.flatMap((d) => {
+                const normalized = normalizeEd2kHash(d.fileHash)
+                return normalized ? [normalized] : []
+              }),
+            )
 
-        const filterCategory = categories.find(c => c.title === categoryTitle)
+            return {
+              categories,
+              downloads: downloads
+                .filter((d) => !!normalizeEd2kHash(d.fileHash))
+                .map((d) => ({
+                  ...d,
+                  category_obj: categories.find((c) => c.id === d.category),
+                })),
+              shared: shared
+                .filter((s) => {
+                  const normalized = normalizeEd2kHash(s.fileHash)
+                  return normalized !== null && !downloadHashes.has(normalized)
+                })
+                .map((d) => ({
+                  ...d,
+                  category_obj: categories.find((c) => c.path === d.path),
+                })),
+            }
+          },
+        )
+
+        const filterCategory = categories.find((c) => c.title === categoryTitle)
         if (categoryTitle && !filterCategory) {
-          throw new Error(`Category ${categoryTitle} not found`)
+          return Response.json([])
         }
 
         const filteredDownloads = categoryTitle
-          ? downloads.filter(d => d.category_obj === filterCategory)
+          ? downloads.filter((d) => d.category_obj === filterCategory)
           : downloads
 
         const filteredShared = categoryTitle
-          ? shared.filter(s => s.category_obj === filterCategory)
+          ? shared.filter((s) => s.category_obj === filterCategory)
           : shared
 
         // qBittorrent structure
         return Response.json([
-          ...filteredDownloads.map((f) => ({
-            hash: f.fileHash,
-            name: f.fileName,
-            size: f.fileSize,
-            tracker: 'http://amulerr',
-            downloaded: f.fileSizeDownloaded,
-            progress: Math.min(99.99, parseFloat(f.progress ?? '0')) / 100,
-            dlspeed: f.speed,
-            eta: f.speed && f.speed > 0 ? (f.fileSize - (f.fileSizeDownloaded ?? 0)) / f.speed : 8640000,
-            state: statusToQbittorrentState(f),
-            content_path: `${f.category_obj?.path}/${f.fileName}`,
-            save_path: f.category_obj?.path,
-            category: f.category_obj?.title,
-            amount_left: f.fileSize - (f.fileSizeDownloaded ?? 0),
-            num_complete: f.sourceCount,
-            num_incomplete: f.sourceCountNotCurrent,
-            num_leechs: f.sourceCountXfer,
-            num_seeds: f.sourceCountA4AF,
-            seen_complete: f.lastSeenComplete,
-            last_activity: f.lastReceived,
-            time_active: f.downloadActiveTime,
-            added_on: Math.floor(Date.now() / 1000) - (f.downloadActiveTime ?? 0)
-          })),
-          ...filteredShared.map((f) => ({
-            hash: f.fileHash,
-            name: f.fileName,
-            size: f.fileSize,
-            tracker: 'http://amulerr',
-            downloaded: f.fileSize,
-            progress: 1,
-            dlspeed: 0,
-            state: "pausedUP" as const,
-            content_path: `${f.path}/${f.fileName}`,
-            save_path: f.path,
-            category: f.category_obj?.title,
-          })),
+          ...filteredDownloads.map((f) => {
+            const savePath = f.category_obj?.path ?? ''
+            const fileName = f.fileName ?? ''
+            const fileSize = f.fileSize ?? 0
+            const fileSizeDownloaded = f.fileSizeDownloaded ?? 0
+            const speed = f.speed ?? 0
+            const amountLeft = torrentAmountLeft(fileSize, fileSizeDownloaded)
+            const progress = clampProgress(f.progress)
+            const now = Math.floor(Date.now() / 1000)
+            return {
+              hash: toQbittorrentHash(f.fileHash),
+              name: fileName,
+              size: fileSize,
+              tracker: 'http://amulerr',
+              downloaded: fileSizeDownloaded,
+              progress,
+              dlspeed: speed,
+              eta: torrentEta(speed, amountLeft),
+              state: statusToQbittorrentState(f),
+              content_path: savePath ? `${savePath}/${fileName}` : fileName,
+              save_path: savePath,
+              category: f.category_obj?.title ?? '',
+              amount_left: amountLeft,
+              num_complete: f.sourceCount ?? 0,
+              num_incomplete: f.sourceCountNotCurrent ?? 0,
+              num_leechs: f.sourceCountXfer ?? 0,
+              num_seeds: f.sourceCountA4AF ?? 0,
+              seen_complete: f.lastSeenComplete ?? 0,
+              last_activity: f.lastReceived ?? 0,
+              time_active: f.downloadActiveTime ?? 0,
+              added_on: now - (f.downloadActiveTime ?? 0),
+              ...qbittorrentTorrentExtras(),
+            }
+          }),
+          ...filteredShared.map((f) => {
+            const savePath = f.path ?? ''
+            const fileName = f.fileName ?? ''
+            return {
+              hash: toQbittorrentHash(f.fileHash ?? ''),
+              name: fileName,
+              size: f.fileSize ?? 0,
+              tracker: 'http://amulerr',
+              downloaded: f.fileSize ?? 0,
+              progress: 1,
+              dlspeed: 0,
+              state: 'pausedUP' as const,
+              content_path: savePath ? `${savePath}/${fileName}` : fileName,
+              save_path: savePath,
+              category: f.category_obj?.title ?? '',
+              ...qbittorrentTorrentExtras(),
+            }
+          }),
         ])
-      }
-    }
+      },
+    },
   },
 })
 
-function statusToQbittorrentState(
-  f: DownloadItem
-) {
+function statusToQbittorrentState(f: DownloadItem) {
   switch (f.status) {
     case 0:
     case 1:
@@ -91,21 +131,21 @@ function statusToQbittorrentState(
     case 3:
     case 10:
       return f.sourceCountXfer && f.sourceCountXfer > 0
-        ? ("downloading" as const)
+        ? ('downloading' as const)
         : f.progress && parseFloat(f.progress) < 100
-          ? ("stalledDL" as const)
-          : "pausedUP" as const
+          ? ('stalledDL' as const)
+          : ('pausedUP' as const)
     case 4:
     case 5:
     case 6:
-      return "error" as const
+      return 'error' as const
     case 7:
-      return "pausedDL" as const
+      return 'pausedDL' as const
     case 8:
-      return "moving" as const
+      return 'moving' as const
     case 9:
-      return "pausedUP" as const
+      return 'pausedUP' as const
     default:
-      return "stalledDL" as const
+      return 'stalledDL' as const
   }
 }

--- a/src/amulerr/src/routes/api.v2.torrents.pause.tsx
+++ b/src/amulerr/src/routes/api.v2.torrents.pause.tsx
@@ -1,6 +1,5 @@
-
 import { useAmule } from '#/amule'
-import { skipFalsy } from '#/lib/array'
+import { hasTorrentHashInput, resolveTorrentHashes } from '#/lib/torrents'
 import { createFileRoute } from '@tanstack/react-router'
 
 // https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#pause-torrents
@@ -9,23 +8,19 @@ export const Route = createFileRoute('/api/v2/torrents/pause')({
     handlers: {
       POST: async ({ request }) => {
         const formData = await request.formData()
-        const hashes = formData
-          .get("hashes")
-          ?.toString()
-          ?.toUpperCase()
-          ?.split("|")
-          .filter(skipFalsy)
+        const rawHashes = formData.get('hashes')?.toString()
 
-        if (hashes?.length) {
+        if (hasTorrentHashInput(rawHashes)) {
           await useAmule(async (amule) => {
+            const hashes = await resolveTorrentHashes(amule, rawHashes)
             for (const hash of hashes) {
               await amule.pauseDownload(hash)
             }
           })
         }
 
-        return new Response("Ok", { status: 200 })
-      }
-    }
+        return new Response('Ok', { status: 200 })
+      },
+    },
   },
 })

--- a/src/amulerr/src/routes/api.v2.torrents.properties.tsx
+++ b/src/amulerr/src/routes/api.v2.torrents.properties.tsx
@@ -1,0 +1,83 @@
+import { useAmule } from '#/amule'
+import { sameEd2kHash } from '#/lib/links'
+import { parseTorrentHash } from '#/lib/torrents'
+import { createFileRoute } from '@tanstack/react-router'
+
+// https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-generic-properties
+//
+// Sonarr/Radarr IsTorrentLoaded() treats any HTTP-200 JSON body as "loaded" (no empty-object check).
+// Missing torrents must return 404 so *rr does not mark a snatch complete prematurely.
+//
+// LazyLibrarian get_torrent() polls this after add; HTTP 404 is falsy (retries), which matches its loop.
+export const Route = createFileRoute('/api/v2/torrents/properties')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const url = new URL(request.url)
+        const rawHash = url.searchParams.get('hash')
+
+        if (!rawHash) {
+          return new Response(null, { status: 404 })
+        }
+
+        const hash = parseTorrentHash(rawHash)
+        if (!hash) {
+          return new Response(null, { status: 404 })
+        }
+
+        const properties = await useAmule(async (amule) => {
+          const downloads = await amule.getDownloadQueue()
+
+          const download = downloads.find((item) =>
+            sameEd2kHash(item.fileHash, hash),
+          )
+          if (download) {
+            const categories = await amule.getCategories()
+            const category = categories.find((c) => c.id === download.category)
+            return {
+              save_path: category?.path ?? '',
+              name: download.fileName ?? '',
+              total_size: download.fileSize ?? 0,
+              total_downloaded: download.fileSizeDownloaded ?? 0,
+              piece_size: 0,
+              pieces_num: 0,
+              pieces_have: 0,
+              addition_date:
+                Math.floor(Date.now() / 1000) -
+                (download.downloadActiveTime ?? 0),
+              completion_date: -1,
+              seeds: download.sourceCount ?? 0,
+              peers: download.sourceCountXfer ?? 0,
+            }
+          }
+
+          const shared = await amule.getSharedFiles()
+          const sharedFile = shared.find((item) =>
+            sameEd2kHash(item.fileHash, hash),
+          )
+          if (sharedFile) {
+            return {
+              save_path: sharedFile.path ?? '',
+              name: sharedFile.fileName ?? '',
+              total_size: sharedFile.fileSize ?? 0,
+              total_downloaded: sharedFile.fileSize ?? 0,
+              piece_size: 0,
+              pieces_num: 0,
+              pieces_have: 0,
+              addition_date: -1,
+              completion_date: -1,
+            }
+          }
+
+          return null
+        })
+
+        if (!properties) {
+          return new Response(null, { status: 404 })
+        }
+
+        return Response.json(properties)
+      },
+    },
+  },
+})

--- a/src/amulerr/src/routes/api.v2.torrents.resume.tsx
+++ b/src/amulerr/src/routes/api.v2.torrents.resume.tsx
@@ -1,6 +1,5 @@
-
 import { useAmule } from '#/amule'
-import { skipFalsy } from '#/lib/array'
+import { hasTorrentHashInput, resolveTorrentHashes } from '#/lib/torrents'
 import { createFileRoute } from '@tanstack/react-router'
 
 // https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#resume-torrents
@@ -9,23 +8,19 @@ export const Route = createFileRoute('/api/v2/torrents/resume')({
     handlers: {
       POST: async ({ request }) => {
         const formData = await request.formData()
-        const hashes = formData
-          .get("hashes")
-          ?.toString()
-          ?.toUpperCase()
-          ?.split("|")
-          .filter(skipFalsy)
+        const rawHashes = formData.get('hashes')?.toString()
 
-        if (hashes?.length) {
+        if (hasTorrentHashInput(rawHashes)) {
           await useAmule(async (amule) => {
+            const hashes = await resolveTorrentHashes(amule, rawHashes)
             for (const hash of hashes) {
               await amule.resumeDownload(hash)
             }
           })
         }
 
-        return new Response("Ok", { status: 200 })
-      }
-    }
+        return new Response('Ok', { status: 200 })
+      },
+    },
   },
 })

--- a/src/amulerr/src/routes/api.v2.torrents.setCategory.tsx
+++ b/src/amulerr/src/routes/api.v2.torrents.setCategory.tsx
@@ -1,6 +1,5 @@
-
 import { useAmule } from '#/amule'
-import { skipFalsy } from '#/lib/array'
+import { hasTorrentHashInput, resolveTorrentHashes } from '#/lib/torrents'
 import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/api/v2/torrents/setCategory')({
@@ -8,24 +7,26 @@ export const Route = createFileRoute('/api/v2/torrents/setCategory')({
     handlers: {
       POST: async ({ request }) => {
         const formData = await request.formData()
-        const hashes = formData
-          .get("hashes")
-          ?.toString()
-          ?.toUpperCase()
-          ?.split("|")
-          .filter(skipFalsy)
-        const categoryTitle = formData.get("category")?.toString()
+        const rawHashes = formData.get('hashes')?.toString()
+        const categoryTitle = formData.get('category')?.toString()
 
-        if (categoryTitle && hashes?.length) {
+        if (categoryTitle && hasTorrentHashInput(rawHashes)) {
           await useAmule(async (amule) => {
+            const hashes = await resolveTorrentHashes(amule, rawHashes)
+            if (!hashes.length) {
+              return
+            }
+
             const categories = await amule.getCategories()
-            const categoryId = categories.find(c => c.title === categoryTitle)?.id
+            const categoryId = categories.find(
+              (c) => c.title === categoryTitle,
+            )?.id
             if (!categoryId) {
               throw new Error(`Category ${categoryTitle} not found`)
             }
 
             for (const hash of hashes) {
-              if (!await amule.setFileCategory(hash, categoryId)) {
+              if (!(await amule.setFileCategory(hash, categoryId))) {
                 throw new Error(`Failed to set category for torrent ${hash}`)
               }
             }
@@ -33,7 +34,7 @@ export const Route = createFileRoute('/api/v2/torrents/setCategory')({
         }
 
         return Response.json({})
-      }
-    }
+      },
+    },
   },
 })

--- a/src/amulerr/src/routes/api.v2.torrents.setForceStart.tsx
+++ b/src/amulerr/src/routes/api.v2.torrents.setForceStart.tsx
@@ -1,0 +1,11 @@
+import { qbittorrentPlainTextResponse } from '#/lib/qbittorrent'
+import { createFileRoute } from '@tanstack/react-router'
+
+// No-op: aMule has no force-start flag; clients call this after add when InitialState=ForceStart.
+export const Route = createFileRoute('/api/v2/torrents/setForceStart')({
+  server: {
+    handlers: {
+      POST: async () => qbittorrentPlainTextResponse('Ok'),
+    },
+  },
+})

--- a/src/amulerr/src/routes/api.v2.torrents.setShareLimits.tsx
+++ b/src/amulerr/src/routes/api.v2.torrents.setShareLimits.tsx
@@ -1,0 +1,11 @@
+import { qbittorrentPlainTextResponse } from '#/lib/qbittorrent'
+import { createFileRoute } from '@tanstack/react-router'
+
+// No-op: aMule has no per-torrent share-limit API; Radarr/Sonarr tolerate success here.
+export const Route = createFileRoute('/api/v2/torrents/setShareLimits')({
+  server: {
+    handlers: {
+      POST: async () => qbittorrentPlainTextResponse('Ok'),
+    },
+  },
+})

--- a/src/amulerr/src/routes/api.v2.torrents.start.tsx
+++ b/src/amulerr/src/routes/api.v2.torrents.start.tsx
@@ -1,6 +1,5 @@
-
 import { useAmule } from '#/amule'
-import { skipFalsy } from '#/lib/array'
+import { hasTorrentHashInput, resolveTorrentHashes } from '#/lib/torrents'
 import { createFileRoute } from '@tanstack/react-router'
 
 // https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#start-torrents
@@ -9,23 +8,19 @@ export const Route = createFileRoute('/api/v2/torrents/start')({
     handlers: {
       POST: async ({ request }) => {
         const formData = await request.formData()
-        const hashes = formData
-          .get("hashes")
-          ?.toString()
-          ?.toUpperCase()
-          ?.split("|")
-          .filter(skipFalsy)
+        const rawHashes = formData.get('hashes')?.toString()
 
-        if (hashes?.length) {
+        if (hasTorrentHashInput(rawHashes)) {
           await useAmule(async (amule) => {
+            const hashes = await resolveTorrentHashes(amule, rawHashes)
             for (const hash of hashes) {
               await amule.resumeDownload(hash)
             }
           })
         }
 
-        return new Response("Ok", { status: 200 })
-      }
-    }
+        return new Response('Ok', { status: 200 })
+      },
+    },
   },
 })

--- a/src/amulerr/src/routes/api.v2.torrents.stop.tsx
+++ b/src/amulerr/src/routes/api.v2.torrents.stop.tsx
@@ -1,6 +1,5 @@
-
 import { useAmule } from '#/amule'
-import { skipFalsy } from '#/lib/array'
+import { hasTorrentHashInput, resolveTorrentHashes } from '#/lib/torrents'
 import { createFileRoute } from '@tanstack/react-router'
 
 // https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#stop-torrents
@@ -9,23 +8,19 @@ export const Route = createFileRoute('/api/v2/torrents/stop')({
     handlers: {
       POST: async ({ request }) => {
         const formData = await request.formData()
-        const hashes = formData
-          .get("hashes")
-          ?.toString()
-          ?.toUpperCase()
-          ?.split("|")
-          .filter(skipFalsy)
+        const rawHashes = formData.get('hashes')?.toString()
 
-        if (hashes?.length) {
+        if (hasTorrentHashInput(rawHashes)) {
           await useAmule(async (amule) => {
+            const hashes = await resolveTorrentHashes(amule, rawHashes)
             for (const hash of hashes) {
               await amule.pauseDownload(hash)
             }
           })
         }
 
-        return new Response("Ok", { status: 200 })
-      }
-    }
+        return new Response('Ok', { status: 200 })
+      },
+    },
   },
 })

--- a/src/amulerr/src/routes/api.v2.torrents.topPrio.tsx
+++ b/src/amulerr/src/routes/api.v2.torrents.topPrio.tsx
@@ -1,0 +1,11 @@
+import { qbittorrentPlainTextResponse } from '#/lib/qbittorrent'
+import { createFileRoute } from '@tanstack/react-router'
+
+// No-op: aMule has no queue priority API; Radarr/Sonarr ignore 409 on real qBittorrent when queueing is off.
+export const Route = createFileRoute('/api/v2/torrents/topPrio')({
+  server: {
+    handlers: {
+      POST: async () => qbittorrentPlainTextResponse('Ok'),
+    },
+  },
+})

--- a/src/amulerr/vitest.config.ts
+++ b/src/amulerr/vitest.config.ts
@@ -1,0 +1,17 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+const rootDir = dirname(fileURLToPath(import.meta.url))
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '#': resolve(rootDir, './src'),
+    },
+  },
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
## Summary

This PR improves aMulerr's qBittorrent Web API compatibility for Sonarr/Radarr, PyMedusa/Medusa, and LazyLibrarian while keeping aMule/eD2K behavior internal and exposing qBittorrent-compatible hashes only at API boundaries.

## Main changes

- Add qBittorrent-compatible app/auth endpoints:
  - `/api/v2/auth/login`
  - `/api/v2/auth/logout`
  - `/api/v2/app/version`
  - `/api/v2/app/webapiVersion`
  - `/api/v2/app/preferences`

- Complete torrent endpoints used by qBittorrent-compatible clients:
  - `/api/v2/torrents/info`
  - `/api/v2/torrents/properties`
  - `/api/v2/torrents/files`
  - `/api/v2/torrents/contents`
  - `/api/v2/torrents/add`
  - `/api/v2/torrents/delete`
  - pause/resume/start/stop
  - `setCategory`
  - no-op compatibility routes for unsupported qBittorrent actions

- Improve Torznab output:
  - add `<link>`
  - add `torznab:attr name="magneturl"`
  - publish aMulerr-generated synthetic magnets

- Harden compatibility boundaries:
  - strict eD2K/qBittorrent hash normalization
  - reject invalid or non-aMulerr hashes before aMule RPC
  - strict magnet and eD2K parsing
  - stable qBittorrent-like JSON fields
  - no negative `eta` / `amount_left`
  - 0..1 progress values
  - stable `/files` and `/contents` response schema
  - controlled errors for invalid add requests

- Rebased on current `main`; `/api/v2/torrents/delete` now combines qBittorrent hash normalization (`hashes=all`, synthetic hashes) with upstream `deleteFiles` handling (physical file removal and `refreshSharedFiles()`).

## Validation

- `pnpm test` → 77/77 OK
- `pnpm run build` → OK
- `docker compose build amulerr` → OK (from `src/`)
- `pnpm run check` → all PR files formatted; 27 pre-existing repo-wide Prettier warnings remain outside this PR scope

## Runtime validation

Runtime validation with aMule + aMulerr + LazyLibrarian + PyMedusa/Medusa is still required before merge.

## Status

Ready for code review.

Not ready to merge until runtime validation is completed.

## Note

Upstream PR #51 also touches category handling. This PR focuses on qBittorrent API compatibility and should be reviewed with awareness of #51 if that lands first.
