### PR TITLE
feat: add qBittorrent app and auth endpoints

### DIFF
--- a/src/amulerr/src/lib/cookies.ts
+++ b/src/amulerr/src/lib/cookies.ts
@@ -1,0 +1,15 @@
+export function isSecureRequest(request: Request) {
+  if (new URL(request.url).protocol === 'https:') {
+    return true
+  }
+  const forwarded = request.headers
+    .get('x-forwarded-proto')
+    ?.split(',')[0]
+    ?.trim()
+    .toLowerCase()
+  return forwarded === 'https'
+}
+
+export function secureCookieSuffix(request: Request) {
+  return isSecureRequest(request) ? '; Secure' : ''
+}

--- a/src/amulerr/src/lib/qbittorrent-app-auth.test.ts
+++ b/src/amulerr/src/lib/qbittorrent-app-auth.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import {
+  defaultQbittorrentPreferences,
+  QBITTORRENT_APP_VERSION,
+  QBITTORRENT_WEBAPI_VERSION,
+} from './qbittorrent'
+
+type RouteHandler = (ctx: { request: Request }) => Promise<Response>
+
+function getHandler(
+  route: {
+    options?: {
+      server?: { handlers?: { GET?: RouteHandler; POST?: RouteHandler } }
+    }
+  },
+  method: 'GET' | 'POST' = 'GET',
+) {
+  const handler = route.options?.server?.handlers?.[method]
+  if (!handler) {
+    throw new Error(`Missing ${method} handler`)
+  }
+  return handler
+}
+
+describe('qbittorrent app/auth helpers', () => {
+  it('returns safe preference defaults', () => {
+    const prefs = defaultQbittorrentPreferences()
+    expect(prefs.max_ratio_enabled).toBe(false)
+    expect(prefs.max_ratio).toBe(-1)
+    expect(prefs.max_seeding_time_enabled).toBe(false)
+    expect(prefs.max_seeding_time).toBe(-1)
+  })
+})
+
+describe('app/auth routes', () => {
+  it('/api/v2/app/webapiVersion returns text/plain semver', async () => {
+    const { Route } = await import('#/routes/api.v2.app.webapiVersion')
+    const response = await getHandler(Route)({
+      request: new Request('http://x/api/v2/app/webapiVersion'),
+    })
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('text/plain')
+    expect(await response.text()).toBe(QBITTORRENT_WEBAPI_VERSION)
+  })
+
+  it('/api/v2/app/version returns qBittorrent-like version text', async () => {
+    const { Route } = await import('#/routes/api.v2.app.version')
+    const response = await getHandler(Route)({
+      request: new Request('http://x/api/v2/app/version'),
+    })
+    expect(response.headers.get('Content-Type')).toBe('text/plain')
+    expect(await response.text()).toBe(QBITTORRENT_APP_VERSION)
+  })
+
+  it('/api/v2/app/preferences returns required JSON fields', async () => {
+    const { Route } = await import('#/routes/api.v2.app.preferences')
+    const response = await getHandler(Route)({
+      request: new Request('http://x/api/v2/app/preferences'),
+    })
+    const body = await response.json()
+    expect(body.max_ratio_enabled).toBe(false)
+    expect(body.max_seeding_time).toBe(-1)
+  })
+
+  it('/api/v2/auth/login returns Ok. and SID cookie', async () => {
+    const { Route } = await import('#/routes/api.v2.auth.login')
+    const response = await getHandler(
+      Route,
+      'POST',
+    )({
+      request: new Request('http://x'),
+    })
+    expect(await response.text()).toBe('Ok.')
+    expect(response.headers.get('Set-Cookie')).toContain('SID=')
+    expect(response.headers.get('Cache-Control')).toBe('no-store')
+  })
+
+  it('/api/v2/auth/login adds Secure to SID cookie over HTTPS', async () => {
+    const { Route } = await import('#/routes/api.v2.auth.login')
+    const response = await getHandler(
+      Route,
+      'POST',
+    )({
+      request: new Request('https://x/api/v2/auth/login'),
+    })
+    expect(response.headers.get('Set-Cookie')).toContain('; Secure')
+  })
+
+  it('/api/v2/auth/logout adds Secure when behind HTTPS proxy', async () => {
+    const { Route } = await import('#/routes/api.v2.auth.logout')
+    const response = await getHandler(
+      Route,
+      'POST',
+    )({
+      request: new Request('http://x/api/v2/auth/logout', {
+        headers: { 'X-Forwarded-Proto': 'https' },
+      }),
+    })
+    expect(response.headers.get('Set-Cookie')).toContain('; Secure')
+  })
+})

--- a/src/amulerr/src/lib/qbittorrent.ts
+++ b/src/amulerr/src/lib/qbittorrent.ts
@@ -1,0 +1,30 @@
+export const QBITTORRENT_WEBAPI_VERSION = '2.11.0'
+export const QBITTORRENT_APP_VERSION = 'v4.6.7'
+
+export function qbittorrentPlainTextResponse(
+  body: string,
+  cacheControl = 'public, max-age=0',
+) {
+  return new Response(body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/plain',
+      'X-Content-Type-Options': 'nosniff',
+      'Cache-Control': cacheControl,
+    },
+  })
+}
+
+/** Safe defaults for *rr / LazyLibrarian preference polling (ratio/seeding limits disabled). */
+export function defaultQbittorrentPreferences() {
+  return {
+    save_path: '/downloads/complete',
+    temp_path_enabled: false,
+    temp_path: '/downloads/incomplete',
+    create_subfolder_enabled: false,
+    max_ratio_enabled: false,
+    max_ratio: -1,
+    max_seeding_time_enabled: false,
+    max_seeding_time: -1,
+  }
+}

--- a/src/amulerr/src/routeTree.gen.ts
+++ b/src/amulerr/src/routeTree.gen.ts
@@ -25,7 +25,10 @@ import { Route as ApiV2TorrentsCreateCategoryRouteImport } from './routes/api.v2
 import { Route as ApiV2TorrentsCategoriesRouteImport } from './routes/api.v2.torrents.categories'
 import { Route as ApiV2TorrentsAddRouteImport } from './routes/api.v2.torrents.add'
 import { Route as ApiV2SyncMaindataRouteImport } from './routes/api.v2.sync.maindata'
+import { Route as ApiV2AuthLogoutRouteImport } from './routes/api.v2.auth.logout'
+import { Route as ApiV2AuthLoginRouteImport } from './routes/api.v2.auth.login'
 import { Route as ApiV2AppWebapiVersionRouteImport } from './routes/api.v2.app.webapiVersion'
+import { Route as ApiV2AppVersionRouteImport } from './routes/api.v2.app.version'
 import { Route as ApiV2AppPreferencesRouteImport } from './routes/api.v2.app.preferences'
 
 const HealthRoute = HealthRouteImport.update({
@@ -111,9 +114,24 @@ const ApiV2SyncMaindataRoute = ApiV2SyncMaindataRouteImport.update({
   path: '/v2/sync/maindata',
   getParentRoute: () => ApiRoute,
 } as any)
+const ApiV2AuthLogoutRoute = ApiV2AuthLogoutRouteImport.update({
+  id: '/v2/auth/logout',
+  path: '/v2/auth/logout',
+  getParentRoute: () => ApiRoute,
+} as any)
+const ApiV2AuthLoginRoute = ApiV2AuthLoginRouteImport.update({
+  id: '/v2/auth/login',
+  path: '/v2/auth/login',
+  getParentRoute: () => ApiRoute,
+} as any)
 const ApiV2AppWebapiVersionRoute = ApiV2AppWebapiVersionRouteImport.update({
   id: '/v2/app/webapiVersion',
   path: '/v2/app/webapiVersion',
+  getParentRoute: () => ApiRoute,
+} as any)
+const ApiV2AppVersionRoute = ApiV2AppVersionRouteImport.update({
+  id: '/v2/app/version',
+  path: '/v2/app/version',
   getParentRoute: () => ApiRoute,
 } as any)
 const ApiV2AppPreferencesRoute = ApiV2AppPreferencesRouteImport.update({
@@ -127,7 +145,10 @@ export interface FileRoutesByFullPath {
   '/api': typeof ApiRouteWithChildren
   '/health': typeof HealthRoute
   '/api/v2/app/preferences': typeof ApiV2AppPreferencesRoute
+  '/api/v2/app/version': typeof ApiV2AppVersionRoute
   '/api/v2/app/webapiVersion': typeof ApiV2AppWebapiVersionRoute
+  '/api/v2/auth/login': typeof ApiV2AuthLoginRoute
+  '/api/v2/auth/logout': typeof ApiV2AuthLogoutRoute
   '/api/v2/sync/maindata': typeof ApiV2SyncMaindataRoute
   '/api/v2/torrents/add': typeof ApiV2TorrentsAddRoute
   '/api/v2/torrents/categories': typeof ApiV2TorrentsCategoriesRoute
@@ -147,7 +168,10 @@ export interface FileRoutesByTo {
   '/api': typeof ApiRouteWithChildren
   '/health': typeof HealthRoute
   '/api/v2/app/preferences': typeof ApiV2AppPreferencesRoute
+  '/api/v2/app/version': typeof ApiV2AppVersionRoute
   '/api/v2/app/webapiVersion': typeof ApiV2AppWebapiVersionRoute
+  '/api/v2/auth/login': typeof ApiV2AuthLoginRoute
+  '/api/v2/auth/logout': typeof ApiV2AuthLogoutRoute
   '/api/v2/sync/maindata': typeof ApiV2SyncMaindataRoute
   '/api/v2/torrents/add': typeof ApiV2TorrentsAddRoute
   '/api/v2/torrents/categories': typeof ApiV2TorrentsCategoriesRoute
@@ -168,7 +192,10 @@ export interface FileRoutesById {
   '/api': typeof ApiRouteWithChildren
   '/health': typeof HealthRoute
   '/api/v2/app/preferences': typeof ApiV2AppPreferencesRoute
+  '/api/v2/app/version': typeof ApiV2AppVersionRoute
   '/api/v2/app/webapiVersion': typeof ApiV2AppWebapiVersionRoute
+  '/api/v2/auth/login': typeof ApiV2AuthLoginRoute
+  '/api/v2/auth/logout': typeof ApiV2AuthLogoutRoute
   '/api/v2/sync/maindata': typeof ApiV2SyncMaindataRoute
   '/api/v2/torrents/add': typeof ApiV2TorrentsAddRoute
   '/api/v2/torrents/categories': typeof ApiV2TorrentsCategoriesRoute
@@ -190,7 +217,10 @@ export interface FileRouteTypes {
     | '/api'
     | '/health'
     | '/api/v2/app/preferences'
+    | '/api/v2/app/version'
     | '/api/v2/app/webapiVersion'
+    | '/api/v2/auth/login'
+    | '/api/v2/auth/logout'
     | '/api/v2/sync/maindata'
     | '/api/v2/torrents/add'
     | '/api/v2/torrents/categories'
@@ -210,7 +240,10 @@ export interface FileRouteTypes {
     | '/api'
     | '/health'
     | '/api/v2/app/preferences'
+    | '/api/v2/app/version'
     | '/api/v2/app/webapiVersion'
+    | '/api/v2/auth/login'
+    | '/api/v2/auth/logout'
     | '/api/v2/sync/maindata'
     | '/api/v2/torrents/add'
     | '/api/v2/torrents/categories'
@@ -230,7 +263,10 @@ export interface FileRouteTypes {
     | '/api'
     | '/health'
     | '/api/v2/app/preferences'
+    | '/api/v2/app/version'
     | '/api/v2/app/webapiVersion'
+    | '/api/v2/auth/login'
+    | '/api/v2/auth/logout'
     | '/api/v2/sync/maindata'
     | '/api/v2/torrents/add'
     | '/api/v2/torrents/categories'
@@ -366,11 +402,32 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV2SyncMaindataRouteImport
       parentRoute: typeof ApiRoute
     }
+    '/api/v2/auth/logout': {
+      id: '/api/v2/auth/logout'
+      path: '/v2/auth/logout'
+      fullPath: '/api/v2/auth/logout'
+      preLoaderRoute: typeof ApiV2AuthLogoutRouteImport
+      parentRoute: typeof ApiRoute
+    }
+    '/api/v2/auth/login': {
+      id: '/api/v2/auth/login'
+      path: '/v2/auth/login'
+      fullPath: '/api/v2/auth/login'
+      preLoaderRoute: typeof ApiV2AuthLoginRouteImport
+      parentRoute: typeof ApiRoute
+    }
     '/api/v2/app/webapiVersion': {
       id: '/api/v2/app/webapiVersion'
       path: '/v2/app/webapiVersion'
       fullPath: '/api/v2/app/webapiVersion'
       preLoaderRoute: typeof ApiV2AppWebapiVersionRouteImport
+      parentRoute: typeof ApiRoute
+    }
+    '/api/v2/app/version': {
+      id: '/api/v2/app/version'
+      path: '/v2/app/version'
+      fullPath: '/api/v2/app/version'
+      preLoaderRoute: typeof ApiV2AppVersionRouteImport
       parentRoute: typeof ApiRoute
     }
     '/api/v2/app/preferences': {
@@ -385,7 +442,10 @@ declare module '@tanstack/react-router' {
 
 interface ApiRouteChildren {
   ApiV2AppPreferencesRoute: typeof ApiV2AppPreferencesRoute
+  ApiV2AppVersionRoute: typeof ApiV2AppVersionRoute
   ApiV2AppWebapiVersionRoute: typeof ApiV2AppWebapiVersionRoute
+  ApiV2AuthLoginRoute: typeof ApiV2AuthLoginRoute
+  ApiV2AuthLogoutRoute: typeof ApiV2AuthLogoutRoute
   ApiV2SyncMaindataRoute: typeof ApiV2SyncMaindataRoute
   ApiV2TorrentsAddRoute: typeof ApiV2TorrentsAddRoute
   ApiV2TorrentsCategoriesRoute: typeof ApiV2TorrentsCategoriesRoute
@@ -403,7 +463,10 @@ interface ApiRouteChildren {
 
 const ApiRouteChildren: ApiRouteChildren = {
   ApiV2AppPreferencesRoute: ApiV2AppPreferencesRoute,
+  ApiV2AppVersionRoute: ApiV2AppVersionRoute,
   ApiV2AppWebapiVersionRoute: ApiV2AppWebapiVersionRoute,
+  ApiV2AuthLoginRoute: ApiV2AuthLoginRoute,
+  ApiV2AuthLogoutRoute: ApiV2AuthLogoutRoute,
   ApiV2SyncMaindataRoute: ApiV2SyncMaindataRoute,
   ApiV2TorrentsAddRoute: ApiV2TorrentsAddRoute,
   ApiV2TorrentsCategoriesRoute: ApiV2TorrentsCategoriesRoute,

--- a/src/amulerr/src/routes/api.v2.app.preferences.tsx
+++ b/src/amulerr/src/routes/api.v2.app.preferences.tsx
@@ -1,21 +1,10 @@
-
+import { defaultQbittorrentPreferences } from '#/lib/qbittorrent'
 import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/api/v2/app/preferences')({
   server: {
     handlers: {
-      GET: async () => {
-        return Response.json({
-          save_path: "/downloads/complete",
-          temp_path_enabled: true,
-          temp_path: "/downloads/incomplete",
-          create_subfolder_enabled: false,
-          max_ratio_enabled: true,
-          max_ratio: 0,
-          max_seeding_time_enabled: true,
-          max_seeding_time: 0,
-        });
-      },
+      GET: async () => Response.json(defaultQbittorrentPreferences()),
     },
   },
 })

--- a/src/amulerr/src/routes/api.v2.app.version.tsx
+++ b/src/amulerr/src/routes/api.v2.app.version.tsx
@@ -1,0 +1,13 @@
+import {
+  QBITTORRENT_APP_VERSION,
+  qbittorrentPlainTextResponse,
+} from '#/lib/qbittorrent'
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/api/v2/app/version')({
+  server: {
+    handlers: {
+      GET: async () => qbittorrentPlainTextResponse(QBITTORRENT_APP_VERSION),
+    },
+  },
+})

--- a/src/amulerr/src/routes/api.v2.app.webapiVersion.tsx
+++ b/src/amulerr/src/routes/api.v2.app.webapiVersion.tsx
@@ -1,19 +1,13 @@
-
+import {
+  QBITTORRENT_WEBAPI_VERSION,
+  qbittorrentPlainTextResponse,
+} from '#/lib/qbittorrent'
 import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/api/v2/app/webapiVersion')({
   server: {
     handlers: {
-      GET: async () => {
-        return new Response(`2.8.19`, {
-          status: 200,
-          headers: {
-            "Content-Type": "text",
-            "X-Content-Type-Options": "nosniff",
-            "Cache-Control": "public, max-age=0",
-          },
-        })
-      }
-    }
+      GET: async () => qbittorrentPlainTextResponse(QBITTORRENT_WEBAPI_VERSION),
+    },
   },
 })

--- a/src/amulerr/src/routes/api.v2.auth.login.tsx
+++ b/src/amulerr/src/routes/api.v2.auth.login.tsx
@@ -1,0 +1,27 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { secureCookieSuffix } from '#/lib/cookies'
+
+// amulerr does not implement authentication. We still return qBittorrent's standard
+// response ("Ok." + SID cookie) so that clients requiring the /api/v2/auth/login step
+// (Prowlarr, Sonarr, Radarr, Medusa, ...) accept the connection.
+const ok = (request: Request) => {
+  const secure = secureCookieSuffix(request)
+  return new Response(`Ok.`, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/plain',
+      'X-Content-Type-Options': 'nosniff',
+      'Set-Cookie': `SID=amulerr; HttpOnly; SameSite=Strict; Path=/${secure}`,
+      'Cache-Control': 'no-store',
+    },
+  })
+}
+
+export const Route = createFileRoute('/api/v2/auth/login')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => ok(request),
+      GET: async ({ request }) => ok(request),
+    },
+  },
+})

--- a/src/amulerr/src/routes/api.v2.auth.logout.tsx
+++ b/src/amulerr/src/routes/api.v2.auth.logout.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { secureCookieSuffix } from '#/lib/cookies'
+
+const ok = (request: Request) => {
+  const secure = secureCookieSuffix(request)
+  return new Response(`Ok.`, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/plain',
+      'X-Content-Type-Options': 'nosniff',
+      'Set-Cookie': `SID=; HttpOnly; SameSite=Strict; Path=/; Max-Age=0${secure}`,
+      'Cache-Control': 'no-store',
+    },
+  })
+}
+
+export const Route = createFileRoute('/api/v2/auth/logout')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => ok(request),
+      GET: async ({ request }) => ok(request),
+    },
+  },
+})


### PR DESCRIPTION
## Summary

Adds qBittorrent app/auth compatibility endpoints so clients can complete login and app discovery.

## Scope

- `/api/v2/auth/login` — returns `Ok.` with `SID` cookie (GET/POST)
- `/api/v2/auth/logout` — clears `SID` cookie (GET/POST)
- `/api/v2/app/version` — qBittorrent-like version text
- `/api/v2/app/webapiVersion` — Web API version text
- `/api/v2/app/preferences` — safe JSON defaults for *arr / LazyLibrarian polling

Supporting helpers: `cookies.ts`, minimal `qbittorrent.ts` (app/auth only).

## Validation

- `pnpm test` (PR scope: `qbittorrent-app-auth.test.ts`) → pass (7/7)
- `pnpm test` (full suite) → 9 pass, 2 fail (pre-existing indexer test/impl mismatch from #57 on `main`)
- `pnpm run build` → pass
- `docker compose build amulerr` → pass (from `src/`)
- `pnpm run check` → fail on ~50 pre-existing upstream files; all files touched by this PR pass `prettier --check` individually

## Manual validation

Not run. To validate before merge:

1. `POST /api/v2/auth/login` → `Ok.` + `Set-Cookie: SID=...`
2. `GET /api/v2/app/version` → text starting with `v`
3. `GET /api/v2/app/webapiVersion` → semver text (e.g. `2.11.0`)
4. `GET /api/v2/app/preferences` → JSON with ratio/seeding limits disabled
5. Configure Sonarr/Radarr/Medusa/LazyLibrarian qBittorrent client → connection test succeeds

## Out of scope

- Torrent read/status routes (`torrents/info`, `properties`, `files`, `contents`)
- Torrent mutation routes (`add`, `delete`, pause/resume)
- Hash/magnet parsing boundary
- Torznab indexer changes (merged in #57)

Reference integration branch: #52
